### PR TITLE
Introduces get file 

### DIFF
--- a/query-service.proto
+++ b/query-service.proto
@@ -5,6 +5,7 @@ import "types.proto";
 
 service Query {
     rpc GetSurvey (GetSurveyRequest) returns (GetSurveyResponse) {}
+    rpc GetFile (GetFileRequest) returns (GetFileResponse) {}
 }
 
 message GetSurveyRequest {
@@ -13,4 +14,12 @@ message GetSurveyRequest {
 
 message GetSurveyResponse {
     RegisteredSurvey survey = 1;
+}
+
+message GetFileRequest {
+    string id = 1;
+}
+
+message GetFileResponse {
+    RegisteredFile file = 1;
 }


### PR DESCRIPTION
Query server should now be able to get a survey by id and get a file by id. 
Get file is used by ingestion implementation in order to ingest by id (it maps the id into the filename so we can find it on the bucket)