### PR TITLE
adds survey id to file (will need it to register file endpoint)

### DIFF
--- a/types.proto
+++ b/types.proto
@@ -16,7 +16,8 @@ message RegisteredSurvey {
 
 message File {
     string name = 1;
-    map<string, string> metadata = 2;
+    string survey_id = 2;
+    map<string, string> metadata = 3;
 }
 message RegisteredFile {
     string id = 1;


### PR DESCRIPTION
We will need the survey id in the file in order to send it to the register file endpoint, but I don't know if this is the best way of adding it. 
If it makes it more complicated in terms of passing file messages to pubsub and others, we could also create a different message type (file-with-survey or something) and use this new type in the register file endpoint.