### PR TITLE
Pack the lines when sending, which is recommended in docs

### DIFF
--- a/query_service_messages.proto
+++ b/query_service_messages.proto
@@ -191,7 +191,7 @@ message PositionQuery {
 // Response messages
 
 message AvailableLines {
-    repeated int32 lines = 1;
+    repeated int32 lines = 1 [packed=true];
 }
 
 // message SearchSurveyListResponse {


### PR DESCRIPTION
The queries for available lines just sends repeated ints. The docs recommend that all these should use `packed=true`, see this, from [here](https://developers.google.com/protocol-buffers/docs/proto#specifying-field-rules).

>For historical reasons, repeated fields of scalar numeric types aren't encoded as efficiently as they could be. New code should use the special option `[packed=true]` to get a more efficient encoding.

Also see [here](https://developers.google.com/protocol-buffers/docs/encoding#packed).