### PR TITLE
Add status message

### DIFF
--- a/query_service_messages.proto
+++ b/query_service_messages.proto
@@ -191,7 +191,7 @@ message PositionQuery {
 // Response messages
 
 message AvailableLines {
-    repeated int32 lines = 1 [packed=true];
+    repeated int32 lines = 1;
 }
 
 // message SearchSurveyListResponse {


### PR DESCRIPTION
Adds an (optional) message to return when the user queries for the status.
The service will for now only give a message if the job is failed, but in the future we might want to add a message for more cases, e.g. for which stage of the ingestion.