### PR TITLE
Add request and response for ListSurvey endpoint

### DIFF
--- a/query_service.proto
+++ b/query_service.proto
@@ -16,6 +16,10 @@ service Query {
     **/
     rpc GetSurvey (SurveyQueryRequest) returns (GetSurveyResponse) {}
     /**
+    Returns a list of all surveys
+    **/
+    rpc ListSurveys (ListSurveysQueryRequest) returns (ListSurveysResponse) {}
+    /**
     Returns a file given its name or id.
     **/
     rpc GetFile (FileQueryRequest) returns (GetFileResponse) {}

--- a/query_service_messages.proto
+++ b/query_service_messages.proto
@@ -16,6 +16,11 @@ message SurveyQueryRequest {
     bool include_metadata = 3; // should metadata be included in the result
 }
 
+message ListSurveysQueryRequest {
+    bool list_files = 1;       // see above
+    bool include_metadata = 2;
+}
+
 message FileQueryRequest {
     Identifier file = 1;
 }
@@ -218,6 +223,10 @@ message DataCoverageResponse {
 message GetSurveyResponse {
     Survey survey = 1;
     repeated File files = 2;
+}
+
+message ListSurveysResponse {
+    repeated GetSurveyResponse surveys = 1;
 }
 
 message GetFileResponse {


### PR DESCRIPTION
See [This Trello card](https://trello.com/c/1e7hWC2y/137-have-getsurvey-endpoint-list-surveys-when-no-id-is-specified) and [this PR on seismic](https://github.com/cognitedata/seismic/pull/89).

With this, there is an option to get all info, i.e. file names and metadata, for all surveys, with the same parameters (flags) as in `GetSurvey`. This may or may not be necessary, but my rationale was that it's better to get all the info at once.