### PR TITLE
Add types to SegYQueryResponse

### DIFF
--- a/types.proto
+++ b/types.proto
@@ -127,10 +127,10 @@ message Trace3D {
 
 message SegYQueryResponse {
     enum Type {
-        TEXT_HEADER = 1;
-        BINARY_HEADER = 2;
-        TRACE_HEADER = 3;
-        TRACE = 4;
+        TEXT_HEADER = 0;
+        BINARY_HEADER = 1;
+        TRACE_HEADER = 2;
+        TRACE = 3;
     }
     Type type = 1;
     bytes content = 2;


### PR DESCRIPTION
To create the Seg-Y file client should know the response type.
Following types added:
* TEXT_HEADER
* BINARY_HEADER
* TRACE_HEADER
* TRACE

The service will send text and binary header first. Next, it will send pairs trace header and trace one by one. As client SDK know the Seg-Y format and can get trace count from binary headers, it can reuse that information to reconstruct the file. 