### PR TITLE
No need to have StreamTrace2D

### DIFF
--- a/query_service.proto
+++ b/query_service.proto
@@ -51,7 +51,7 @@ service Query {
     /** 
     Returns all traces in a slice (inline or crossline) given its index
     **/
-    rpc GetSliceByLine (LineSliceQueryRequest) returns (stream StreamTrace2D) {}
+    rpc GetSliceByLine (LineSliceQueryRequest) returns (stream Trace1D) {}
     /**
     Returns a slice with traces closest to a given arbitrary line
     **/

--- a/types.proto
+++ b/types.proto
@@ -82,10 +82,6 @@ message Trace2D {
     repeated Trace1D trace = 1;
 }
 
-message StreamTrace2D {
-    Trace1D trace = 1;
-}
-
 // Volume (2D array of traces)
 message Trace3D {
     repeated Trace2D trace = 1;


### PR DESCRIPTION
We should not wrap Trace1D to StreamTrace2D.

Stream Trace1D means a list of Trace1D which is similar to:
message Trace2D {
    repeated Trace1D trace = 1;
}