### PR TITLE
Add DELETING file status

### DIFF
--- a/types.proto
+++ b/types.proto
@@ -94,5 +94,6 @@ enum FileStep {
     INSERT_TRACE_HEADERS = 2;
     INSERT_DATA = 3;
     COMPUTE_COVERAGE = 4;
+    DELETING = 254;
     DELETE = 255;
 }


### PR DESCRIPTION
This is needed in order to disable calls against files that are being deleted, but have not yet been deleted. ([This card on Trello](https://trello.com/c/R81wwyak/178-do-not-allow-queries-against-files-that-are-in-the-process-of-deleting))