### PR TITLE
Use int wrapper instead of int

### DIFF
--- a/types.proto
+++ b/types.proto
@@ -5,6 +5,7 @@ syntax = "proto3";
 package com.cognite.seismic;
 
 import "google/protobuf/struct.proto";
+import "google/protobuf/wrappers.proto";
 
 // -----
 
@@ -71,9 +72,10 @@ message LineSelect {
     }
 }
 
+// Object to store the line range. From and to are optional
 message LineRange {
-    int32 from = 1;
-    int32 to = 2;
+    google.protobuf.Int32Value from = 1;
+    google.protobuf.Int32Value to = 2;
 }
 
 // The underlying array of floats for all traces


### PR DESCRIPTION
See [previous PR](https://github.com/cognitedata/seismic-proto/pull/40).
Use wrappers instead, then we can handle non-positive values, which is unlikely, but it may happen according to SEGY spec.