### PR TITLE
Add Inline and Crossline to Trace

### DIFF
--- a/types.proto
+++ b/types.proto
@@ -81,8 +81,8 @@ message LineRange {
 // The underlying array of floats for all traces
 message Trace {
     bytes trace_header = 1;
-    int32 iline = 2;
-    int32 xline = 3;
+    google.protobuf.Int32Value iline = 2;
+    google.protobuf.Int32Value xline = 3;
     repeated float trace = 4;
 }
 


### PR DESCRIPTION
Currently, we return a stream(Trace) for getCube and getSlice queries. However, in both cases, if the user receives only a stream, they need to reconstruct the 2D structure of the lines in the volume/slice.

There are some discussion on this topic. More details can be found [here](https://trello.com/c/Npn73fop/199-discuss-the-line-structure-of-getvolumeby-and-getsliceby-queries) 

In conclusion, we want to add `inline` and `crossline` information along with a Trace.