### PR TITLE
Adds endpoints for cross-project file sharing

### DIFF
--- a/cognite/seismic/protos/ingest_service.proto
+++ b/cognite/seismic/protos/ingest_service.proto
@@ -63,10 +63,10 @@ service Ingest {
     List projects that have access to a specific file.
     Only users in the CDF project that owns the file have access to this method
     **/
-    rpc ListFileAccess(ListFileAccessRequest) returns (google.protobuf.Empty) {}
+    rpc ListFileAccess(ListFileAccessRequest) returns (ProjectListResponse) {}
     /**
     Add or remove access to a file for CDF projects
     Only users in the CDF project that owns the file have access to this method
     **/
-    rpc EditFileAccess(EditFileAccessRequest) returns (ProjectListResponse) {}
+    rpc EditFileAccess(EditFileAccessRequest) returns (google.protobuf.Empty) {}
 }

--- a/cognite/seismic/protos/ingest_service.proto
+++ b/cognite/seismic/protos/ingest_service.proto
@@ -27,6 +27,8 @@ You can verify the status of this process by calling the Status endpoint  with t
 
 As soon as the status of the processing job is set to complete, data from the file will be available with the query service
 
+When a file is registered in a CDF project, this project owns the file. It is then allowed to share access with other
+CDF projects
 **/
 service Ingest {
     /**
@@ -57,4 +59,14 @@ service Ingest {
     Updates survey metadata
     **/
     rpc EditSurvey (EditSurveyRequest) returns (EditSurveyResponse) {}
+    /**
+    List projects that have access to a specific file.
+    Only users in the CDF project that owns the file have access to this method
+    **/
+    rpc ListFileAccess(ListFileAccessRequest) returns (google.protobuf.Empty) {}
+    /**
+    Add or remove access to a file for CDF projects
+    Only users in the CDF project that owns the file have access to this method
+    **/
+    rpc EditFileAccess(EditFileAccessRequest) returns (ProjectListResponse) {}
 }

--- a/cognite/seismic/protos/ingest_service_messages.proto
+++ b/cognite/seismic/protos/ingest_service_messages.proto
@@ -159,7 +159,7 @@ message EditFileAccessRequest {
     Identifier file = 1;    // [required] Either name or id of a file
     Identifier project = 2; // [required] Either name or id of a project
     /**
-    If neither add or remove are set, or if both are set to true, a toggle behaviour will be assumed
+    If neither add or remove are set, or if both are set to true, add will be assumed
     **/
     bool add = 3;           // Add project access to this file
     bool remove = 4;        // Remove project access from this file

--- a/cognite/seismic/protos/ingest_service_messages.proto
+++ b/cognite/seismic/protos/ingest_service_messages.proto
@@ -159,10 +159,10 @@ message EditFileAccessRequest {
     Identifier file = 1;    // [required] Either name or id of a file
     Identifier project = 2; // [required] Either name or id of a project
     /**
-    If force_add is set, will set access to true regardless of the current access status
-    If false, will toggle the access - remove it if the project has it or add it otherwise
+    If neither add or remove are set, or if both are set to true, a toggle behaviour will be assumed
     **/
-    bool force_add = 3;
+    bool add = 3;           // Add project access to this file
+    bool remove = 4;        // Remove project access from this file
 }
 
 message ProjectListResponse {

--- a/cognite/seismic/protos/ingest_service_messages.proto
+++ b/cognite/seismic/protos/ingest_service_messages.proto
@@ -150,3 +150,21 @@ message EditSurveyRequest {
 message EditSurveyResponse {
     Survey survey = 1;
 }
+
+message ListFileAccessRequest {
+    Identifier file = 1; // [required] Either name or id of a file
+}
+
+message EditFileAccessRequest {
+    Identifier file = 1;    // [required] Either name or id of a file
+    Identifier project = 2; // [required] Either name or id of a project
+    /**
+    If force_add is set, will set access to true regardless of the current access status
+    If false, will toggle the access - remove it if the project has it or add it otherwise
+    **/
+    bool force_add = 3;
+}
+
+message ProjectListResponse {
+    repeated Project project = 1;
+}

--- a/cognite/seismic/protos/query_service.proto
+++ b/cognite/seismic/protos/query_service.proto
@@ -51,9 +51,13 @@ service Query {
     **/
     rpc GetSurvey (SurveyQueryRequest) returns (GetSurveyResponse) {}
     /**
-    Lists all surveys available in the server. Optionally, includes their lists of files.
+    Lists all surveys owned by this project. Optionally, includes their lists of files.
     **/
     rpc ListSurveys (ListSurveysQueryRequest) returns (SurveyWithFilesResponse) {}
+    /**
+    Lists all files available to this project, both owned by it and shared with it
+    **/
+    rpc ListFiles (google.protobuf.Empty) returns (ListFilesResponse) {}
     /**
     Search surveys based on two criteria:
         Coverage polygon of files in the survey are within an area delimited by a specified polygon

--- a/cognite/seismic/protos/query_service.proto
+++ b/cognite/seismic/protos/query_service.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 package com.cognite.seismic;
 
+import "google/protobuf/empty.proto";
 import "cognite/seismic/protos/types.proto";
 import "cognite/seismic/protos/query_service_messages.proto";
 
@@ -55,7 +56,7 @@ service Query {
     **/
     rpc ListSurveys (ListSurveysQueryRequest) returns (SurveyWithFilesResponse) {}
     /**
-    Lists all files available to this project, both owned by it and shared with it
+    Lists all files available, both owned by the authorized CDF project and shared with it
     **/
     rpc ListFiles (google.protobuf.Empty) returns (ListFilesResponse) {}
     /**

--- a/cognite/seismic/protos/query_service_messages.proto
+++ b/cognite/seismic/protos/query_service_messages.proto
@@ -259,6 +259,10 @@ message GetFileResponse {
     string last_step = 5;
 }
 
+message ListFilesResponse {
+    repeated File files = 1;
+}
+
 message GetBinaryHeaderResponse {
     BinaryHeader meta = 1;
 }

--- a/cognite/seismic/protos/types.proto
+++ b/cognite/seismic/protos/types.proto
@@ -63,6 +63,11 @@ message File {
     map<string, string> metadata = 3;
 }
 
+message Project {
+    string id = 1;
+    string alias = 2;
+}
+
 // Specify either id or name to find a file or survey.
 message Identifier {
     oneof findby {


### PR DESCRIPTION
Endpoints added are:
- list/add/remove projects that hava access to files (only allowed to the owner project)
- list files - will list all files a project has access to. This is different from list surveys, which will list surveys and files it owns for compatibility reasons. List surveys behaviour may be changed in he future for consistency or it can be removed and replaced by list files after agreement with current users