### PR TITLE
api v1.5

### DIFF
--- a/cognite/seismic/protos/query_service.proto
+++ b/cognite/seismic/protos/query_service.proto
@@ -7,157 +7,87 @@ import "cognite/seismic/protos/query_service_messages.proto";
 
 /**
 Service for querying data and metadata from seismic files in Cognite Data Fusion (CDF) seismic datastore
-We use the word `File` to refer to a single seismic file/dataset/cube. Queries on a file require it to have been
+We use the word `File` to refer to a single seismic file/dataset/cube/volume. Queries on a file require it to have been
 previously ingested into CDF using (ingest_service.proto)
-
-Queries are divided in:
-
-    - Metadata:
-
-    General information and headers for surveys and files
-
-    - Geometry and grid:
-
-    Information on a file's grid and positioning, such as coverage and range of inlines and crosslines
-
-    - Trace:
-
-    Find a single trace in the file. A trace will include header, position information and samples.
-    More details about the trace format can be found on its definition in (types.proto)
-
-    - Vertical slice:
-
-    Get 2D vertical slices of samples (thus 1D arrays of traces). The slices can be based on a single defined line or
-    in an arbitrarily defined line with interpolation.
-
-    - Area:
-
-     Get 3D volumes of samples (thus 2D arrays of traces) defined by a region in the horizontal plane
-
-    - Horizontal slice:
-
-     Get 2D horizontal slices of samples defined by a region in the horizontal plane and a specific index in depth/time
-
-    - Artificial sampling:
-
-    Get the (calculated/interpolated) values of properties in the file/cube given arbitrary positions
 **/
 
 service Query {
 
-    // Metadata queries
+  // Metadata queries
 
-    /**
-    Finds one survey given its name or id. Optionally, lists its associated files.
-    **/
-    rpc GetSurvey (SurveyQueryRequest) returns (GetSurveyResponse) {}
-    /**
-    Lists all surveys owned by this project. Optionally, includes their lists of files.
-    **/
-    rpc ListSurveys (ListSurveysQueryRequest) returns (SurveyWithFilesResponse) {}
-    /**
-    Lists all files available, both owned by the authorized CDF project and shared with it
-    **/
-    rpc ListFiles (google.protobuf.Empty) returns (ListFilesResponse) {}
-    /**
-    Search surveys based on two criteria:
-        Coverage polygon of files in the survey are within an area delimited by a specified polygon
-        Filters on metadata of both the survey and the file
-    Both criteria are optional and can be combined for a more detailed search.
-    **/
-    rpc SearchSurveys (SearchSurveyRequest) returns (SurveyWithFilesResponse) {}
-    /**
-    Returns file metadata given its name or id.
-    **/
-    rpc GetFile (FileQueryRequest) returns (GetFileResponse) {}
-    /**
-    Returns a binary header given its file name or id.
-    **/
-    rpc GetBinaryHeader (HeaderFileQueryRequest) returns (GetBinaryHeaderResponse) {}
-    /**
-    Returns a text header given its file name or id.
-    **/
-    rpc GetTextHeader (HeaderFileQueryRequest) returns (GetTextHeaderResponse) {}
-
-
-    // Geometry and grid queries
-
-    /**
-    Returns the coverage for a given file identified by its id or name.
-    The coverage is represented by a polygon either in WKT or geojson and represents the area covered by traces
-    in the file.
-    There can be holes in the polygon if traces do not exist in an area inside of it.
-    **/
-    rpc GetFileDataCoverage (FileCoverageRequest) returns (DataCoverageResponse) {}
-    /**
-    Returns the full range of the inlines and crosslines in the file, i.e. the minimum and maximum inline and crossline
-    **/
-    rpc GetFileLineRange (FileQueryRequest) returns (LineRangeResponse) {}
-    /**
-    Returns the set of valid crossline indices for a specific inline, in a given file
-    **/
-    rpc GetCrosslinesByInline (FileLineQueryRequest) returns (AvailableLines) {}
-    /**
-    Returns the set of valid inline indices for a specific crossline, in a given file
-    **/
-    rpc GetInlinesByCrossline (FileLineQueryRequest) returns (AvailableLines) {}
+  /**
+  Finds one survey given its name or id. Optionally, lists its associated files.
+  **/
+  rpc GetSurvey (SurveyQueryRequest) returns (GetSurveyResponse) {}
+  /**
+  Lists all surveys owned by this project. Optionally, includes their lists of files.
+  **/
+  rpc ListSurveys (ListSurveysQueryRequest) returns (SurveyWithFilesResponse) {}
+  /**
+  Lists all files available, both owned by the authorized CDF project and shared with it
+  **/
+  rpc ListFiles (google.protobuf.Empty) returns (ListFilesResponse) {}
+  /**
+  Search surveys based on two criteria:
+      Coverage polygon of files in the survey are within an area delimited by a specified polygon
+      Filters on metadata of both the survey and the file
+  Both criteria are optional and can be combined for a more detailed search.
+  **/
+  rpc SearchSurveys (SearchSurveyRequest) returns (SurveyWithFilesResponse) {}
+  /**
+  Returns file metadata given its name or id.
+  **/
+  rpc GetFile (FileQueryRequest) returns (GetFileResponse) {}
+  /**
+  Returns a binary header given its file name or id.
+  **/
+  rpc GetBinaryHeader (HeaderFileQueryRequest) returns (GetBinaryHeaderResponse) {}
+  /**
+  Returns a text header given its file name or id.
+  **/
+  rpc GetTextHeader (HeaderFileQueryRequest) returns (GetTextHeaderResponse) {}
 
 
-    // Trace queries
-    /**
-    Returns the trace in a file that is closest to a point given its coordinates (x,y)
-    **/
-    rpc GetTraceByCoordinates (CoordinateTraceQueryRequest) returns (Trace) {}
-    /**
-    Returns a trace for each coordinate (inline, xline) from the input stream
-    **/
-    rpc GetTracesByLine(stream LineTraceQueryRequest) returns (stream Trace) {}
+  // Geometry and grid queries
+  /**
+  Returns the coverage for a given file identified by its id or name.
+  The coverage is represented by a polygon either in WKT or geojson and represents the area covered by traces
+  in the file.
+  There can be holes in the polygon if traces do not exist in an area inside of it.
+  **/
+  rpc GetFileDataCoverage (FileCoverageRequest) returns (DataCoverageResponse) {}
+  /**
+  Returns the set of valid crossline indices for a specific inline, in a given file
+  **/
+  rpc GetCrosslinesByInline (FileLineQueryRequest) returns (AvailableLines) {}
+  /**
+  Returns the set of valid inline indices for a specific crossline, in a given file
+  **/
+  rpc GetInlinesByCrossline (FileLineQueryRequest) returns (AvailableLines) {}
 
 
-
-    // Slice queries
-
-    /**
-    Returns all or a subset of traces in a slice (inline or crossline) given its index (and optionally from/to)
-    **/
-    rpc GetSliceByLine (LineSliceQueryRequest) returns (stream Trace) {}
-    /**
-    Returns a slice with traces following a path determined by an arbitrary line.
-    Depending on interpolating method, these can be either real traces in the file that are closest to the path or
-    synthetic traces generated by interpolation of the traces in the file.
-    **/
-    rpc GetSliceByGeometry (GeometrySliceQueryRequest) returns (stream Trace) {}
-
-
-
-    // Area queries
-
-    /**
-    Returns a volume with all traces inside a given range of inlines and a given range of crosslines
-    **/
-    rpc GetCubeByLines (LineCubeRequest) returns (stream Trace) {}
-    /**
-    Returns a volume with all traces with x, y coordinates inside an arbitrary 2D polygon
-    **/
-    rpc GetCubeByGeometry (GeometryCubeRequest) returns (stream Trace) {}
-    /**
-    Returns a SEG-Y file.
-    Can retrieve a full file or create a new cropped file filtering on areas of interest only.
-    **/
-    rpc GetSegYFile (SegYQueryRequest) returns (stream SegYQueryResponse) {}
-
-
-    // Depth-indexed area queries
-
-    /**
-    Returns a horizontal slice for a given depth or time and area constrained by a range of inlines and crosslines
-    **/
-    rpc GetTimeSliceByLines (LineTimeSliceQueryRequest) returns (stream SurfacePoint) {}
-    /**
-    Returns a horizontal slice for a given depth or time and area constrained by an arbitrary 2D polygon
-    **/
-    rpc GetTimeSliceByGeometry (GeometryTimeSliceQueryRequest) returns (stream SurfacePoint) {}
-
-    // Volume queries
-    rpc GetVolume(VolumeRequest) returns (stream Trace) {}
+  // Trace queries
+  /**
+  Returns the trace in a file that is closest to a point given its coordinates (x,y)
+  **/
+  rpc GetTraceByCoordinates (CoordinateTraceQueryRequest) returns (Trace) {}
+  /**
+  Returns a trace for each coordinate (inline, xline) from the input stream
+  **/
+  rpc GetTracesByLine(stream LineTraceQueryRequest) returns (stream Trace) {}
+  /**
+  Returns a volume bounded by the provided ranges
+  **/
+  rpc GetVolume(VolumeRequest) returns (stream Trace) {}
+  /**
+  Returns a slice with traces following a path determined by an arbitrary line.
+  Depending on interpolating method, these can be either real traces in the file that are closest to the path or
+  synthetic traces generated by interpolation of the traces in the file.
+  **/
+  rpc GetSliceByGeometry (GeometrySliceQueryRequest) returns (stream Trace) {}
+  /**
+  Returns a SEG-Y file.
+  Can retrieve a full file or create a new cropped file filtering on areas of interest only.
+  **/
+  rpc GetSegYFile (SegYQueryRequest) returns (stream SegYQueryResponse) {}
 }

--- a/cognite/seismic/protos/query_service_messages.proto
+++ b/cognite/seismic/protos/query_service_messages.proto
@@ -12,38 +12,38 @@ import "google/protobuf/wrappers.proto";
 // Requests for metadata and coverage
 
 message SurveyQueryRequest {
-    Identifier survey = 1;        // name or id of the survey
-    bool list_files = 2;          // set to true to list the survey files in the response (default: false)
-    bool include_metadata = 3;    // set to true to include metadata in the response (default: false)
+  Identifier survey = 1;        // name or id of the survey
+  bool list_files = 2;          // set to true to list the survey files in the response (default: false)
+  bool include_metadata = 3;    // set to true to include metadata in the response (default: false)
 }
 
 message ListSurveysQueryRequest {
-    bool list_files = 1;          // set to true to list the survey files in the response (default: false)
-    bool include_metadata = 2;    // set to true to include metadata in the response (default: false)
+  bool list_files = 1;          // set to true to list the survey files in the response (default: false)
+  bool include_metadata = 2;    // set to true to include metadata in the response (default: false)
 }
 
 message FileQueryRequest {
-    Identifier file = 1;         // name or id of the file
+  Identifier file = 1;         // name or id of the file
 }
 
 message FileLineQueryRequest {
-    Identifier file = 1;         // name or id of the file
-    int32 line = 2;              // number of the selected inline or crossline in the file
+  Identifier file = 1;         // name or id of the file
+  int32 line = 2;              // number of the selected inline or crossline in the file
 }
 
 message HeaderFileQueryRequest {
-    Identifier file = 1;         // name or id of the file
-    bool include_raw_header = 2; // set to true to include the raw header in the response (default: false)
+  Identifier file = 1;         // name or id of the file
+  bool include_raw_header = 2; // set to true to include the raw header in the response (default: false)
 }
 
 message FileCoverageRequest {
-    Identifier file = 1;         // name or id of the file
-    CRS crs = 2;                 // [optional] If CRS provided converts coverage to given CRS. Otherwise, will return in the file's original CRS
-    bool in_wkt = 3;             // set this to true to return in WKT format. Otherwise, response will be in geojson format by default
+  Identifier file = 1;         // name or id of the file
+  CRS crs = 2;                 // [optional] If CRS provided converts coverage to given CRS. Otherwise, will return in the file's original CRS
+  bool in_wkt = 3;             // set this to true to return in WKT format. Otherwise, response will be in geojson format by default
 }
 
 message NavigationPolygonRequest {
-    Identifier survey = 1;       // name or id of the survey
+  Identifier survey = 1;       // name or id of the survey
 }
 
 // ---
@@ -54,11 +54,11 @@ message NavigationPolygonRequest {
 Request a single trace from a file by index (inline AND crossline)
 **/
 message LineTraceQueryRequest {
-    Identifier file = 1;
-    PositionQuery position = 3;
-    bool include_trace_header = 4;
-    bool include_trace_coordinates = 5;
-    bool include_trace_data = 6;
+  Identifier file = 1;
+  PositionQuery position = 3;
+  bool include_trace_header = 4;
+  bool include_trace_coordinates = 5;
+  bool include_trace_data = 6;
 }
 
 /**
@@ -66,74 +66,74 @@ Request a single trace from a file by coordinates (x AND y). If x and y don't fa
 will return the closest trace to it.
 **/
 message CoordinateTraceQueryRequest {
-    Identifier file = 1;
-    CoordinateQuery coordinates = 2;
-    float max_radius = 3; // only return traces if closer than this to the actual point in the file
-    bool include_trace_header = 4;
+  Identifier file = 1;
+  CoordinateQuery coordinates = 2;
+  float max_radius = 3; // only return traces if closer than this to the actual point in the file
+  bool include_trace_header = 4;
 }
 
 /**
 Request a slice of traces from a file by index (inline OR crossline), and optionally specify min and max range
 **/
 message LineSliceQueryRequest {
-    Identifier file = 1;
-    LineSelect line = 2;
-    bool include_trace_header = 3;
-    LineRange range = 4;
+  Identifier file = 1;
+  LineSelect line = 2;
+  bool include_trace_header = 3;
+  LineRange range = 4;
 }
 
 /**
 Request a slice of traces from a file by coordinates of start and end of an arbitrary line
 **/
 message GeometrySliceQueryRequest {
-    Identifier file = 1;
-    Geometry arbitrary_line = 2;
-    InterpolationMethod interpolation_method = 3;
+  Identifier file = 1;
+  Geometry arbitrary_line = 2;
+  InterpolationMethod interpolation_method = 3;
 }
 
 /**
 Request a volume of traces from a file by range of inlines and crosslines
 **/
 message LineCubeRequest {
-    Identifier file = 1;
-    LineBasedRectangle rectangle = 2;
-    bool include_trace_header = 3;
+  Identifier file = 1;
+  LineBasedRectangle rectangle = 2;
+  bool include_trace_header = 3;
 }
 
 /**
 Request a volume of traces from a file with coordinates inside an arbitrary polygon
 **/
 message GeometryCubeRequest {
-    Identifier file = 1;
-    Geometry geometry = 2;
-    bool include_trace_header = 3;
+  Identifier file = 1;
+  Geometry geometry = 2;
+  bool include_trace_header = 3;
 }
 
 /**
 Request a time slice from a file and filter by range of inlines and crosslines
 **/
 message LineTimeSliceQueryRequest {
-    Identifier file = 1;
-    LineBasedRectangle rectangle = 2;
-    google.protobuf.Int32Value z = 3;             // either time or depth according to the file
+  Identifier file = 1;
+  LineBasedRectangle rectangle = 2;
+  google.protobuf.Int32Value z = 3;             // either time or depth according to the file
 }
 
 /**
 Request a time slice from a file and filter by coordinates inside an arbitrary polygon
 **/
 message GeometryTimeSliceQueryRequest {
-    Identifier file = 1;
-    Geometry geometry = 2;
-    google.protobuf.Int32Value z = 3;             // either time or depth according to the file
+  Identifier file = 1;
+  Geometry geometry = 2;
+  google.protobuf.Int32Value z = 3;             // either time or depth according to the file
 }
 
 /**
 Request a volume from a file by range of inlines, crosslines and time
 **/
 message VolumeRequest {
-    Identifier file = 1;
-    LineBasedVolume volume = 2;
-    bool include_trace_header = 3;
+  Identifier file = 1;
+  LineBasedVolume volume = 2;
+  bool include_trace_header = 3;
 }
 
 
@@ -146,30 +146,30 @@ Filter the area included in the SEGY file by a polygon defined either by spatial
 or by a set of inline and crossline indices
 **/
 message SegYQueryRequest {
-    Identifier file = 1;
-    oneof query {
-        Geometry polygon = 2;
-        LineBasedRectangle lines = 3;
-    }
+  Identifier file = 1;
+  oneof query {
+    Geometry polygon = 2;
+    LineBasedRectangle lines = 3;
+  }
 }
 
 /**
 Request a pseudo-trace (sequence of values) representing the values for the described path in a file
 **/
 message PathQueryRequest {
-    Identifier file = 1;
-    Geometry geometry = 2;
-    bool include_trace_header = 3;
+  Identifier file = 1;
+  Geometry geometry = 2;
+  bool include_trace_header = 3;
 }
 
 /**
 Request to search surveys inside a polygon or by metadata
 **/
 message SearchSurveyRequest {
-    Geometry polygon = 1;
-    MetadataFilter survey_metadata = 2;
-    MetadataFilter file_metadata = 3;
-    bool include_metadata = 4;
+  Geometry polygon = 1;
+  MetadataFilter survey_metadata = 2;
+  MetadataFilter file_metadata = 3;
+  bool include_metadata = 4;
 }
 
 // ---
@@ -180,42 +180,42 @@ message SearchSurveyRequest {
 Range of inline and crossline indices defining a 2D region
 **/
 message LineBasedRectangle {
-    PositionQuery top_left = 1;
-    PositionQuery bottom_right = 2;
+  PositionQuery top_left = 1;
+  PositionQuery bottom_right = 2;
 }
 
 /**
 Range of inline, crossline and time indices defining a volume
 **/
 message LineBasedVolume {
-    LineDescriptor iline = 1;
-    LineDescriptor xline = 2;
-    LineDescriptor z = 3;
+  LineDescriptor iline = 1;
+  LineDescriptor xline = 2;
+  LineDescriptor z = 3;
 }
 
 message MetadataFilter {
-    map<string, string> filter = 1;
+  map<string, string> filter = 1;
 }
 
 message KeyValueFilter {
-    string key = 1;
-    string value = 2;
+  string key = 1;
+  string value = 2;
 }
 
 /**
 Point defined by its x and y coordinates
 **/
 message CoordinateQuery {
-    float x = 1;
-    float y = 2;
+  float x = 1;
+  float y = 2;
 }
 
 /**
 Point defined by its inline and crossline indices
 **/
 message PositionQuery {
-    int32 iline = 1;
-    int32 xline = 2;
+  int32 iline = 1;
+  int32 xline = 2;
 }
 
 // ---
@@ -223,90 +223,87 @@ message PositionQuery {
 // Response messages
 
 message AvailableLines {
-    repeated int32 lines = 1;
-}
-
-message LineRangeResponse {
-    LineDescriptor inline = 1;
-    LineDescriptor xline = 2;
+  repeated int32 lines = 1;
 }
 
 message SurveyWithFilesResponse {
-    repeated SurveyWithFiles surveys = 1;
+  repeated SurveyWithFiles surveys = 1;
 }
 
 message SurveyWithFiles {
-    string id = 1;
-    string name = 2;
-    map<string, string> metadata = 3;
-    repeated File files = 4;
+  string id = 1;
+  string name = 2;
+  map<string, string> metadata = 3;
+  repeated File files = 4;
 }
 
 message DataCoverageResponse {
-    Geometry polygon = 1;
+  Geometry polygon = 1;
 }
 
 message GetSurveyResponse {
-    Survey survey = 1;
-    repeated File files = 2;
+  Survey survey = 1;
+  repeated File files = 2;
 }
 
 message GetFileResponse {
-    File file = 1;
-    string crs = 2;
-    string path = 3;
-    string survey_name = 4;
-    string last_step = 5;
+  File file = 1;
+  string crs = 2;
+  string path = 3;
+  string survey_name = 4;
+  string last_step = 5;
+  LineDescriptor inline_range = 6;
+  LineDescriptor xline_range = 7;
 }
 
 message ListFilesResponse {
-    repeated File files = 1;
+  repeated File files = 1;
 }
 
 message GetBinaryHeaderResponse {
-    BinaryHeader meta = 1;
+  BinaryHeader meta = 1;
 }
 
 message GetTextHeaderResponse {
-    TextHeader meta = 1;
+  TextHeader meta = 1;
 }
 
 message TextHeader {
-    string file_id = 1;
-    string header = 2;
-    string raw_header = 3;
+  string file_id = 1;
+  string header = 2;
+  string raw_header = 3;
 }
 
 message BinaryHeader {
-    string file_id = 1;
-    int32 traces = 2;
-    int32 trace_data_type = 3;
-    int32 fixed_length_traces = 4;
-    int32 segy_revision = 5;
-    int32 auxtraces = 6;
-    int32 interval = 7;
-    int32 interval_original = 8;
-    int32 samples = 9;
-    int32 samples_original = 10;
-    int32 ensemble_fold = 11;
-    int32 vertical_sum = 12;
-    int32 trace_type_sorting_code = 13;
-    int32 sweep_type_code = 14;
-    int32 sweep_frequency_start = 15;
-    int32 sweep_frequency_end = 16;
-    int32 sweep_length = 17;
-    int32 sweep_channel = 18;
-    int32 sweep_taper_start = 19;
-    int32 sweep_taper_end = 20;
-    int32 sweep_taper_type = 21;
-    int32 correlated_traces = 22;
-    int32 amplitude_recovery = 23;
-    int32 original_measurement_system = 24;
-    int32 impulse_signal_polarity = 25;
-    int32 vibratory_polarity_code = 26;
-    bytes raw_header = 27;
+  string file_id = 1;
+  int32 traces = 2;
+  int32 trace_data_type = 3;
+  int32 fixed_length_traces = 4;
+  int32 segy_revision = 5;
+  int32 auxtraces = 6;
+  int32 interval = 7;
+  int32 interval_original = 8;
+  int32 samples = 9;
+  int32 samples_original = 10;
+  int32 ensemble_fold = 11;
+  int32 vertical_sum = 12;
+  int32 trace_type_sorting_code = 13;
+  int32 sweep_type_code = 14;
+  int32 sweep_frequency_start = 15;
+  int32 sweep_frequency_end = 16;
+  int32 sweep_length = 17;
+  int32 sweep_channel = 18;
+  int32 sweep_taper_start = 19;
+  int32 sweep_taper_end = 20;
+  int32 sweep_taper_type = 21;
+  int32 correlated_traces = 22;
+  int32 amplitude_recovery = 23;
+  int32 original_measurement_system = 24;
+  int32 impulse_signal_polarity = 25;
+  int32 vibratory_polarity_code = 26;
+  bytes raw_header = 27;
 }
 
 message SegYQueryResponse {
-    bytes content = 1;
+  bytes content = 1;
 }


### PR DESCRIPTION
changes in the api:

* GetFileLineRange removed, the line extent is now part of the GetFile response
* GetSliceByLine removed, use GetVolume instead
* GetCubeByLines removed, use GetVolume instead
* GetTimeSliceByLines removed, use GetVolume instead
* GetCubeByGeometry removed, no replacement for the time being until multi-tier storage is implemented, this endpoint is too slow to be of any practical use
* GetTimeSliceByGeometry removed, no replacement for the time being until multi-tier storage is implemented, this endpoint is too slow to be of any practical use