### PR TITLE
Messagepack

### DIFF
--- a/cognite/seismic/protos/v1/seismic_service_datatypes.proto
+++ b/cognite/seismic/protos/v1/seismic_service_datatypes.proto
@@ -111,7 +111,10 @@ Example:
  }
 **/
 message VolumeDef {
-    string json = 1;  // Uses the Volume Definition schema
+    oneof content {
+        string json = 1;  // Uses the Volume Definition schema
+        bytes msgpack = 2;  // Same as `json` field, but as MessagePack binary
+    }
 }
 
 /**

--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -111,6 +111,7 @@ message SearchSeismicStoresRequest {
     bool include_headers = 5; // if true, include text and binary headers in the response
     bool include_coverage = 4; // Deprecated. Use `coverage` instead.
     CoverageSpec coverage = 7; // If specified, include coverage
+    bool volumedef_as_msgpack = 8; // If true and include_volume_defs is true, outputs as msgpack
 }
 
 message EditSeismicStoreRequest {

--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -111,7 +111,7 @@ message SearchSeismicStoresRequest {
     bool include_headers = 5; // if true, include text and binary headers in the response
     bool include_coverage = 4; // Deprecated. Use `coverage` instead.
     CoverageSpec coverage = 7; // If specified, include coverage
-    bool volumedef_as_msgpack = 8; // If true and include_volume_defs is true, outputs as msgpack
+    bool volumedef_as_msgpack = 5000000; // If true and include_volume_defs is true, outputs as msgpack
 }
 
 message EditSeismicStoreRequest {


### PR DESCRIPTION
* This commit adds messagepack to the volumedef protos in a way that the end-user will not need to care about -- it is entirely compatible.
* I will test streaming messagepack instead of json for seismicstore search endpoint on Greenfield. If it doesn't provide any performance benefits, I will revert those changes as well as any protobuf changes. 