### PR TITLE
Feat: Add Search Files endpoint to v1

### DIFF
--- a/cognite/seismic/protos/v1/seismic_service.proto
+++ b/cognite/seismic/protos/v1/seismic_service.proto
@@ -107,4 +107,6 @@ service SeismicAPI {
     Can retrieve a full file or create a new cropped file filtering on areas of interest only.
     **/
     rpc GetSegYFile (SegYSeismicRequest) returns (stream SegYSeismicResponse) {}
+
+    rpc SearchFiles(SearchFilesRequest) returns (stream File) {}
 }

--- a/cognite/seismic/protos/v1/seismic_service_datatypes.proto
+++ b/cognite/seismic/protos/v1/seismic_service_datatypes.proto
@@ -4,7 +4,6 @@ Messages that describe data types used by Seismic Datastore in Cognite Data Fusi
 syntax = "proto3";
 package com.cognite.seismic.v1;
 
-import "google/protobuf/wrappers.proto";
 import "cognite/seismic/protos/types.proto";
 
 message Coordinate {

--- a/cognite/seismic/protos/v1/seismic_service_datatypes.proto
+++ b/cognite/seismic/protos/v1/seismic_service_datatypes.proto
@@ -131,7 +131,7 @@ Can search by id, name, or prefix.
 message SearchSpec {
     oneof findby {
         int64 id = 1;
-        string id_string = 6; // Surveys must have string format ids. Other objects can't use this.
+        string id_string = 6; // Surveys and files must have string format ids. Other objects can't use this.
         // External ids only exist for partitions and seismics.
         string external_id = 2;  // Exact match required
         string external_id_substring = 3;

--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -174,3 +174,14 @@ message SegYSeismicRequest {
 message SegYSeismicResponse {
     bytes content = 1;
 }
+
+/**
+
+    File operations
+
+**/
+
+// Used to search files by id, extid, extid substring, name, name substring
+message SearchFilesRequest {
+    SearchSpec spec = 1;
+}


### PR DESCRIPTION
Adds search endpoint to v1, because they currently only exist for v0 in the form of "get" and "list". The return type File is already thin, with only metadata, name, id, extid, so no modifications are needed. 