### PR TITLE
Rename Horizon to Surface

### DIFF
--- a/cognite/seismic/protos/query_service_messages.proto
+++ b/cognite/seismic/protos/query_service_messages.proto
@@ -118,7 +118,7 @@ message LineSlabRequest {
     LineBasedRectangle rectangle = 2;
     oneof z {
         int32 constant = 3;
-        Horizon horizon = 4;
+        Surface surface = 4;
     }
     google.protobuf.Int32Value n_above = 5;
     google.protobuf.Int32Value n_below = 6;
@@ -185,7 +185,7 @@ message SearchSurveyRequest {
 /**
 Range of z_values to use in time/depth slice queries
  */
-message Horizon {
+message Surface {
     repeated int32 z_values = 1;
 }
 

--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -18,8 +18,11 @@ import "cognite/seismic/protos/types.proto";
 **/
 
 message CreateSurveyRequest {
+    // Short descriptive name
     string name = 1;
+    // Key-value pairs of metadata for the survey.
     map<string, string> metadata = 2;
+    // Identifier for correlation with systems outside CDF
     ExternalId external_id = 3;
     CRS crs = 4; // CRS used by all members
     SurveyGridTransformation grid_transformation = 5; // Optional


### PR DESCRIPTION
Unfortunate naming - better fix earlier than later. Proto tags are unchanged, so wire format is compatible. It'll break implementations when merged, though.