### PR TITLE
Explicity DeduceFromTraces field in SurveyGridTransformation

### DIFF
--- a/cognite/seismic/protos/query_service_messages.proto
+++ b/cognite/seismic/protos/query_service_messages.proto
@@ -178,6 +178,7 @@ message SearchSurveyRequest {
     MetadataFilter survey_metadata = 2;
     MetadataFilter file_metadata = 3;
     bool include_metadata = 4;
+    bool include_grid_transformation = 5;
 }
 
 // ---

--- a/cognite/seismic/protos/types.proto
+++ b/cognite/seismic/protos/types.proto
@@ -41,6 +41,8 @@ enum Handedness {
 }
 
 // Specify the transformation by an origin point and the crossline azimuth
+// Format inspired by IOGP guidance note 373-7-2 section 2.3.2.4.
+// https://ge0mlib.com/papers/Guide/IOGP/373-07-2-1_2017.pdf
 message P6Transformation {
     Handedness handedness = 1;
     // A point in the grid
@@ -57,6 +59,11 @@ message P6Transformation {
     int32 xline_bin_inc = 7;
 }
 
+// Have the seismic service try to deduce the affine transformation for each file by
+// reading trace coordinates
+message DeduceFromTraces {
+};
+
 // Specify the transformation by giving the coordinates of three or more corners
 message TraceCorners {
     repeated DoubleTraceCoordinates corners = 1;
@@ -67,6 +74,7 @@ message SurveyGridTransformation {
     oneof transformation {
         P6Transformation p6_transformation = 1;
         TraceCorners trace_corners = 2;
+        DeduceFromTraces deduce_from_traces = 3;
     }
 }
 


### PR DESCRIPTION
That way callers can reset surveys back to the old behavior of deducing.