### PR TITLE
Return SurveyGridTransformation to users in v1 too

### DIFF
--- a/cognite/seismic/protos/v1/seismic_service_datatypes.proto
+++ b/cognite/seismic/protos/v1/seismic_service_datatypes.proto
@@ -44,6 +44,8 @@ message Survey {
     string name = 2;
     map<string, string> metadata = 3;
     ExternalId external_id = 4;
+    string crs = 5;
+    SurveyGridTransformation grid_transformation = 6;
 }
 
 /**

--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -21,7 +21,7 @@ message CreateSurveyRequest {
     string name = 1;
     map<string, string> metadata = 2;
     ExternalId external_id = 3;
-    CRS crs = 4; // CRS used by all members
+    string crs = 4; // CRS used by all members
     SurveyGridTransformation grid_transformation = 5; // Optional
 }
 
@@ -31,6 +31,7 @@ message SearchSurveysRequest {
     bool list_seismic_store_ids = 3;  // Set to true to list the survey's seismic stores in the response. Only tenant users can see this.
     bool include_metadata = 4;       // set to true to include survey metadata in the response (default: false)
     CoverageParameters include_coverage = 5;    // set this field to include coverage in the response (default: false)
+    bool include_grid_transformation = 6;    // set this field to include the manually specified grid transformation in the response (default: false)
 }
 
 message SearchSurveyResponse {
@@ -44,7 +45,7 @@ message EditSurveyRequest {
     Identifier survey = 1;
     OptionalMap metadata = 2;  // The existing metadata will be replaced with this metadata.
     ExternalId external_id = 3;
-    CRS crs = 4; // CRS used by all members
+    string crs = 4; // CRS used by all members
     SurveyGridTransformation grid_transformation = 5; // Optional
 }
 


### PR DESCRIPTION
I didn't realize that Survey was duplicated in v1.

Also redefined fields in v1's `CreateSurveyRequest` and `EditSurveyRequest` to take crs as string instead of the CRS type, to be consistent with the rest of the v1 API. These endpoints are unimplemented, so it should be fine, right?