### PR TITLE
Update seismic_service_datatypes.proto

### DIFF
--- a/cognite/seismic/protos/v1/seismic_service_datatypes.proto
+++ b/cognite/seismic/protos/v1/seismic_service_datatypes.proto
@@ -7,7 +7,9 @@ package com.cognite.seismic.v1;
 import "cognite/seismic/protos/types.proto";
 
 message Coordinate {
+    //The x value of the coordinate
     float x = 1;
+    //The y value of the coordinate
     float y = 2;
 }
 


### PR DESCRIPTION
Adding description to data types. However I noticed in seismic SDK docs we have a CRS field that doesn't exits here @amorken is it alright?