### PR TITLE
Stream SurveyWithFiles instead of returning as a list

### DIFF
--- a/cognite/seismic/protos/query_service.proto
+++ b/cognite/seismic/protos/query_service.proto
@@ -55,6 +55,12 @@ service Query {
     Lists all surveys owned by this project. Optionally, includes their lists of files.
     **/
     rpc ListSurveys (ListSurveysQueryRequest) returns (SurveyWithFilesResponse) {}
+
+    /**
+    Streams all surveys owned by this project. Optionally, includes their lists of files
+    **/
+    rpc StreamSurveys (ListSurveysQueryRequest) returns (stream SurveyWithFiles) {}
+
     /**
     Lists all files available, both owned by the authorized CDF project and shared with it
     **/
@@ -66,6 +72,16 @@ service Query {
     Both criteria are optional and can be combined for a more detailed search.
     **/
     rpc SearchSurveys (SearchSurveyRequest) returns (SurveyWithFilesResponse) {}
+
+    /**
+    Search surveys based on two criteria:
+        Coverage polygon of files in the survey are within an area delimited by a specified polygon
+        Filters on metadata of both the survey and the file
+    Both criteria are optional and can be combined for a more detailed search.
+    Returns results as a stream instead of a list.
+    **/
+    rpc StreamSearchSurveys (SearchSurveyRequest) returns (stream SurveyWithFiles) {}
+
     /**
     Returns file metadata given its name or id.
     **/


### PR DESCRIPTION
PGS couldn't list surveys with metadata and files included because it exceeded the fixed limit for a single protobuf message on the client side. Rather than having to rely on increasing this limit, it would be better if the results were just streamed back instead.

I guess these endpoints would be added to the 0.2 sdk as new methods, then we could replace the old methods in the 0.3 sdk release (And maybe revert the ability to increase the limit on protobuf message size?).

In theory, even this fix could eventually run into the same problem with PGS, if they added enough files to a survey. And i'm unsure if there's a memory limit on how much metadata can be added for a single file