### PR TITLE
Feat: Add force option to CreateSeismicRequest

### DIFF
--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -76,11 +76,11 @@ message CreateSeismicRequest {
     oneof volume {
         VolumeDef volume_def = 5;  // Define the volume as VolumeDef format
         Geometry geometry = 7;  // Defines the volume as WKT or GeoJson
+        bool empty = 10;  // If true, will create a seismic with an empty cutout
     }
     OptionalMap metadata = 6;
     TextHeader text_header = 8;  // Optionally set a custom text header
     BinaryHeader binary_header = 9;  // Optionally set a custom binary header
-    bool force_create = 10;  // If true, will create a seismic even if there are no traces included in the cutout.
 }
 
 message SearchSeismicsRequest {

--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -80,6 +80,7 @@ message CreateSeismicRequest {
     OptionalMap metadata = 6;
     TextHeader text_header = 8;  // Optionally set a custom text header
     BinaryHeader binary_header = 9;  // Optionally set a custom binary header
+    bool force_create = 10;  // If true, will create a seismic even if there are no traces included in the cutout.
 }
 
 message SearchSeismicsRequest {


### PR DESCRIPTION
Add force option that creates a seismic even if the intersection is empty (contains no traces).