### PR TITLE
SBS-3771 Build more docs bettererer

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -11,19 +11,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Remove previous docs
         run: rm -rf docs
-      - name: Build HTML docs with protoc-gen-doc
-        run: |
-          docker run --rm \
-            -v $(pwd)/docs/docs:/out \
-            -v $(pwd):/protos \
-            pseudomuto/protoc-gen-doc -I/protos $(find $PWD/cognite/seismic/protos -name '*.proto' -printf "protos/cognite/seismic/protos/%P ")
-      - name: Build markdown docs with protoc-gen-doc
-        run: |
-          docker run --rm \
-            -v $(pwd)/docs/docs:/out \
-            -v $(pwd):/protos \
-            pseudomuto/protoc-gen-doc -I/protos $(find $PWD/cognite/seismic/protos -name '*.proto' -printf "protos/cognite/seismic/protos/%P ") \
-            --doc_opt=markdown,docs.md
+      - name: Build docs
+        run: ./build-docs.sh
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@4.1.1
         with:

--- a/.github/workflows/validate-proto.yml
+++ b/.github/workflows/validate-proto.yml
@@ -14,3 +14,12 @@ jobs:
 
       - name: Lint
         run: prototool lint
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Remove previous docs
+        run: rm -rf docs
+      - name: Build docs
+        run: ./build-docs.sh

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -1,9 +1,11 @@
-#!/bin/bash
+#!/bin/bash -e
 # Build HTML and markdown docs from Protocol Buffer definitions,
 # using https://github.com/pseudomuto/protoc-gen-doc
 
 # Remove any existing built docs
 test -d docs && rm -rf docs
+test -d dockerout && rm -rf dockerout
+mkdir -p docs/docs dockerout
 
 # All protocol buffer files
 # These include a number of proto files that aren't part of the API, notably persisted_trace.proto
@@ -21,19 +23,29 @@ V0_PROTOFILES=$(for PROTO in $V0_PROTOS ; do echo protos/cognite/seismic/protos/
 V1_PROTOS="v1/seismic_service v1/seismic_service_messages v1/seismic_service_datatypes types"
 V1_PROTOFILES=$(for PROTO in $V1_PROTOS ; do echo protos/cognite/seismic/protos/${PROTO}.proto ; done )
 
+API_PROTOFILES=$(for PROTO in $V1_PROTOS ${V0_PROTOS% types}; do echo protos/cognite/seismic/protos/${PROTO}.proto ; done )
 
-# Build HTML docs
-docker run --rm -v $(pwd)/docs/docs:/out -v $(pwd):/protos \
-    pseudomuto/protoc-gen-doc -I/protos $PROTOFILES --doc_opt=html,all.html
-docker run --rm -v $(pwd)/docs/docs:/out -v $(pwd):/protos \
-    pseudomuto/protoc-gen-doc -I/protos $V0_PROTOFILES --doc_opt=html,v0.html
-docker run --rm -v $(pwd)/docs/docs:/out -v $(pwd):/protos \
-    pseudomuto/protoc-gen-doc -I/protos $V1_PROTOFILES --doc_opt=html,v1.html
+# We use a separate directory for docker output, as docker creates
+# files with odd ownership. We copy/edit outputs over to docs/docs later.
+DOCKER_COMMAND="docker run --rm -v $(pwd)/dockerout:/out -v $(pwd):/protos pseudomuto/protoc-gen-doc -I/protos"
+
+# Build HTML docs and copy to output directory
+$DOCKER_COMMAND $PROTOFILES --doc_opt=html,all.html
+$DOCKER_COMMAND $API_PROTOFILES --doc_opt=html,index.html
+$DOCKER_COMMAND $V0_PROTOFILES --doc_opt=html,v0.html
+$DOCKER_COMMAND $V1_PROTOFILES --doc_opt=html,v1.html
+
+cp dockerout/*.html docs/docs/
 
 # Build Markdown docs
-docker run --rm -v $(pwd)/docs/docs:/out -v $(pwd):/protos \
-    pseudomuto/protoc-gen-doc -I/protos $PROTOFILES --doc_opt=markdown,docs.md
-docker run --rm -v $(pwd)/docs/docs:/out -v $(pwd):/protos \
-    pseudomuto/protoc-gen-doc -I/protos $V0_PROTOFILES --doc_opt=markdown,v0.md
-docker run --rm -v $(pwd)/docs/docs:/out -v $(pwd):/protos \
-    pseudomuto/protoc-gen-doc -I/protos $V1_PROTOFILES --doc_opt=markdown,v1.md
+$DOCKER_COMMAND $PROTOFILES --doc_opt=markdown,all.md
+$DOCKER_COMMAND $API_PROTOFILES --doc_opt=markdown,docs.md
+$DOCKER_COMMAND $V0_PROTOFILES --doc_opt=markdown,v0.md
+$DOCKER_COMMAND $V1_PROTOFILES --doc_opt=markdown,v1.md
+
+# Copy markdown docs to output dir, but patch in a preamble first
+for mdfile in dockerout/*.md; do
+    cat markdown_preamble.md $mdfile > docs/docs/$(basename $mdfile)
+done
+
+rm -rf dockerout

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Build HTML and markdown docs from Protocol Buffer definitions,
+# using https://github.com/pseudomuto/protoc-gen-doc
+
+# Remove any existing built docs
+test -d docs && rm -rf docs
+
+# All protocol buffer files
+# These include a number of proto files that aren't part of the API, notably persisted_trace.proto
+# and ingest_job.proto. Those should probably be moved out of this repository.
+PROTOFILES=$(find $PWD/cognite/seismic/protos -name '*.proto' -printf "protos/cognite/seismic/protos/%P ")
+
+# Protocol buffer files describing the v0 API, in the process of being phased out
+# Ideally this should be determined by just recursing through the imports in query_service.proto
+# and ingest_service.proto
+V0_PROTOS="query_service ingest_service query_service_messages ingest_service_messages types"
+V0_PROTOFILES=$(for PROTO in $V0_PROTOS ; do echo protos/cognite/seismic/protos/${PROTO}.proto ; done )
+
+# Protocol buffer files describing the v1 API.
+# Ideally this should be determined by just recursing through the imports in v1/seismic_service.proto
+V1_PROTOS="v1/seismic_service v1/seismic_service_messages v1/seismic_service_datatypes types"
+V1_PROTOFILES=$(for PROTO in $V1_PROTOS ; do echo protos/cognite/seismic/protos/${PROTO}.proto ; done )
+
+
+# Build HTML docs
+docker run --rm -v $(pwd)/docs/docs:/out -v $(pwd):/protos \
+    pseudomuto/protoc-gen-doc -I/protos $PROTOFILES --doc_opt=html,all.html
+docker run --rm -v $(pwd)/docs/docs:/out -v $(pwd):/protos \
+    pseudomuto/protoc-gen-doc -I/protos $V0_PROTOFILES --doc_opt=html,v0.html
+docker run --rm -v $(pwd)/docs/docs:/out -v $(pwd):/protos \
+    pseudomuto/protoc-gen-doc -I/protos $V1_PROTOFILES --doc_opt=html,v1.html
+
+# Build Markdown docs
+docker run --rm -v $(pwd)/docs/docs:/out -v $(pwd):/protos \
+    pseudomuto/protoc-gen-doc -I/protos $PROTOFILES --doc_opt=markdown,docs.md
+docker run --rm -v $(pwd)/docs/docs:/out -v $(pwd):/protos \
+    pseudomuto/protoc-gen-doc -I/protos $V0_PROTOFILES --doc_opt=markdown,v0.md
+docker run --rm -v $(pwd)/docs/docs:/out -v $(pwd):/protos \
+    pseudomuto/protoc-gen-doc -I/protos $V1_PROTOFILES --doc_opt=markdown,v1.md

--- a/cognite/seismic/protos/v1/seismic_service.proto
+++ b/cognite/seismic/protos/v1/seismic_service.proto
@@ -7,125 +7,132 @@ import "cognite/seismic/protos/v1/seismic_service_datatypes.proto";
 import "cognite/seismic/protos/v1/seismic_service_messages.proto";
 
 /**
-Service for querying data and metadata from seismic tracestore in Cognite Data Fusion (CDF) seismic datastore.
-
-Queries are done primarily on cubes, with some management endpoints for tracestores & partitions. 
-
-Queries are divided in:
-    Metadata: General information and headers for surveys and files
-    Trace: Retrieve traces, be it by geometry, line or volume
-    Artificial sampling: Get the (calculated/interpolated) values of properties in the file/tracestore given arbitrary positions
+ * Service for querying data and metadata from seismic tracestore in Cognite Data Fusion (CDF) seismic datastore.
+ *
+ * Queries are done primarily on cubes, with some management endpoints for tracestores & partitions.
+ *
+ * Queries are divided in:
+ *   Metadata: General information and headers for surveys and files
+ *   Trace: Retrieve traces, be it by geometry, line or volume
+ *   Artificial sampling: Get the (calculated/interpolated) values of properties in the file/tracestore given arbitrary positions
 **/
-
 service SeismicAPI {
-// Metadata queries
-    rpc CreateSurvey (CreateSurveyRequest) returns (Survey) {}
+    // Metadata queries
+
     /**
-    Lists all surveys accessible to the client. Optionally includes Cubes associated with the surveys.
-    
-    Can optionally search surveys based on both/either of two criteria:
-        Coverage polygon of files in the survey are within an area delimited by a specified polygon
-        Filters on metadata of both the survey and the file
-    **/
+     * Creates a Survey object in the data model. A Survey object represents a grouping of seismic data
+     * in the same area and normally sharing acquisition and most processing parameters.
+     * Capabilities: Requires Seismic:WRITE capability to the CDF tenant.
+     */
+    rpc CreateSurvey (CreateSurveyRequest) returns (Survey) {}
+
+    /**
+     * Lists all surveys accessible to the client. Optionally includes Cubes associated with the surveys.
+     *
+     * Can optionally search surveys based on both/either of two criteria:
+     *   Coverage polygon of files in the survey are within an area delimited by a specified polygon
+     *   Filters on metadata of both the survey and the file
+     */
     rpc SearchSurveys (SearchSurveysRequest) returns (stream SearchSurveyResponse) {}
 
     /**
-    Modify the metadata for a survey.
-    **/
+     * Modify the metadata for a survey.
+     */
     rpc EditSurvey (EditSurveyRequest) returns (Survey) {}
 
     /**
-    Deletes a specified survey. Must have ALL scope and Write capabilities.
-   
-    In the case of Surveys, the "name" should be input into the external_ids field of the Identifier.
-    **/
+     * Deletes a specified survey. Must have ALL scope and Write capabilities.
+     *
+     * In the case of Surveys, the "name" should be input into the external_ids field of the Identifier.
+     */
     rpc DeleteSurvey(DeleteSurveyRequest) returns (DeleteSurveyResponse) {}
-    
 
     /**
-    Create new Seismics and assign them to partitions.
-    Seismics are mostly immutable save for their name and metadata. The user needs to delete an existing cutout and create a new one
-    if e.g. the definition or the seismic store must be changed
-    **/
+     * Create new Seismics and assign them to partitions.
+     * Seismics are mostly immutable save for their name and metadata. The user needs to delete an existing cutout and create a new one
+     * if e.g. the definition or the seismic store must be changed
+     */
     rpc CreateSeismic (CreateSeismicRequest) returns (Seismic) {}
 
     /**
-    Returns Seismic metadata given its id.
-    Can optionally retrieve seismic store & partition info if user has the right scope.
-    Use GetVolume to retrieve traces.
-    **/
+     * Returns Seismic metadata given its id.
+     * Can optionally retrieve seismic store & partition info if user has the right scope.
+     * Use GetVolume to retrieve traces.
+     */
     rpc SearchSeismics (SearchSeismicsRequest) returns (stream Seismic) {}
 
     /**
-    Edit the specified seismic. Although cutout definitions can't be changed, their names can.
-    If user wants to modify the definition or the owning partition, they should instead create a new partition and delete the old one.
-    **/
+     * Edit the specified seismic. Seismic object names and metadata can be changed.
+     * The cutout definition, however, cannot be changed.
+     * To modify the definition or the owning partition, delete the seismic object
+     * and create a new one.
+     */
     rpc EditSeismic (EditSeismicRequest) returns (Seismic) {}
 
     /**
-    Delete seismics.
-    **/
+     * Delete seismic objects.
+     */
     rpc DeleteSeismic (DeleteSeismicRequest) returns (DeleteSeismicResponse) {}
 
     /**
-    Search and retrieve seismic stores. Can only retrieve seismic stores you own.
-    **/
+     * Search and retrieve seismic stores. Can only retrieve seismic stores you own.
+     */
     rpc SearchSeismicStores (SearchSeismicStoresRequest) returns (stream SeismicStore) {}
 
     /**
-    Set the name of a tracestore.
-    **/
+     * Set the name of a seismic store object.
+     **/
     rpc EditSeismicStore (EditSeismicStoreRequest) returns (SeismicStore) {}
 
     /**
-    Delete a seismic store. If any seismics still reference the specified seismic store, the request will fail.
-    **/
+     * Delete a seismic store. If any seismics still reference the specified seismic store, the request will fail.
+     */
     rpc DeleteSeismicStore (DeleteSeismicStoreRequest) returns (DeleteSeismicStoreResponse) {}
 
     /**
-    Create partition, possibly setting a name.
-    **/
+     * Create a data partition, optionally setting a name.
+     */
     rpc CreatePartition (CreatePartitionRequest) returns (Partition) {}
 
     /**
-    Returns the partition(s) specified, with the same search options as the other search endpoints.
-    **/
+     * Returns the partition(s) specified, with the same search options as the other search endpoints.
+     */
     rpc SearchPartitions (SearchPartitionsRequest) returns (stream Partition) {}
 
     /**
-    Edit partitions. The only modifiable field is the name
-    **/
+     * Edit partitions. The only modifiable field is the name
+     */
     rpc EditPartition (EditPartitionRequest) returns (Partition) {}
 
     /**
-    Delete the specified partition, and return whether it was successfully deleted.
-    **/
-    rpc DeletePartition (DeletePartitionRequest) returns (DeletePartitionResponse) {} 
+     * Delete the specified partition, and return whether it was successfully deleted.
+     */
+    rpc DeletePartition (DeletePartitionRequest) returns (DeletePartitionResponse) {}
 
     /**
-    Request a volume of traces by range of inlines, crosslines and time
-    **/
+     * Request a volume of traces by range of inlines, crosslines and time
+     */
     rpc GetVolume(VolumeRequest) returns (stream com.cognite.seismic.Trace) {}
 
     /**
-    Fetches seismic data in SEG-Y format.
-    The stream of responses each contain a byte array that must be written sequentially to a
-    file to produce a SEG-Y file. The ordering of traces in the output is unspecified.
-    
-    The request object can be used to specify whether the file should contain the whole set
-    of traces in the source dataset or a subset of the traces (ie. a cropped file). See 
-    SegYSeismicRequest for more information.
-    Returns a stream of SegYSeismicResponse objects, each containing a fragment of a SEG-Y
-    data stream.
-    **/
+     * Fetch seismic data in SEG-Y format.
+     * The stream of responses each contain a byte array that must be written sequentially to a
+     * file to produce a SEG-Y file. The ordering of traces in the output is unspecified.
+
+     * The request object can be used to specify whether the file should contain the whole set
+     * of traces in the source dataset or a subset of the traces (ie. a cropped file). See
+     * SegYSeismicRequest for more information.
+     * Returns a stream of SegYSeismicResponse objects, each containing a fragment of a SEG-Y
+     * data stream.
+     */
     rpc GetSegYFile (SegYSeismicRequest) returns (stream SegYSeismicResponse) {}
 
     /**
-    Retrieves File objects describing the seismic files registered with the tenant. 
-    Search criteria can be specified in the SearchFilesRequest, restricting the data retrieved
-    to a subset of the files in the tenant. See SearchFilesRequest for more information.
-    Returns a stream of file objects, terminating all files matching the search criteria have been
-    returned.
-    **/
+     * Retrieves File objects describing the seismic files registered with the tenant.
+     * Search criteria can be specified in the SearchFilesRequest, restricting the data retrieved
+     * to a subset of the files in the tenant. See SearchFilesRequest for more information.
+     * Returns a stream of file objects, terminating all files matching the search criteria have been
+     * returned.
+     */
     rpc SearchFiles(SearchFilesRequest) returns (stream File) {}
 }

--- a/markdown_preamble.md
+++ b/markdown_preamble.md
@@ -1,0 +1,4 @@
+---
+sidebar: auto
+sidebarDepth: 2
+---


### PR DESCRIPTION
This moves the invocations of protoc-gen-doc into a shell script to give us a bit more room for evil hackery.

We now build separate files for v0 and v1 APIs, one page for both v0 and v1 APIs, and finally one with all the proto files, like we have done previously. This latter variant should probably go away, as there are proto files in this repository that are not part of the API as such.

Finally we include a preamble in the Markdown files to get a sidebar when they're converted to HTML for the docs site later.