### PR TITLE
Remove seismics from partition

### DIFF
--- a/cognite/seismic/protos/v1/seismic_service_datatypes.proto
+++ b/cognite/seismic/protos/v1/seismic_service_datatypes.proto
@@ -105,8 +105,9 @@ message Partition {
     string external_id = 2;
     //The human-friendly name for this partition
     string name = 3;
-    //The list of seismics that belong to this partition
-    repeated Seismic seismics = 4;
+    reserved 4;  // Used to be list of seismics.
+    //The list of ids of seismics that belong to this partition
+    repeated int64 seismic_ids = 5;
 }
 
 /**

--- a/cognite/seismic/protos/v1/seismic_service_datatypes.proto
+++ b/cognite/seismic/protos/v1/seismic_service_datatypes.proto
@@ -105,7 +105,7 @@ message Partition {
     string external_id = 2;
     //The human-friendly name for this partition
     string name = 3;
-    reserved 4;  // Used to be list of seismics.
+    repeated Seismic seismics = 4;  // DEPRECATED: This field will always be empty. Use seismic search by partition instead.
     //The list of ids of seismics that belong to this partition
     repeated int64 seismic_ids = 5;
 }


### PR DESCRIPTION
On very large datasets, the embedded seismics exceeded the max message size (10MB) for partitions. So we will remove the embedded seismics and instead return a list of IDs. Seismics can instead be retrieved using the "by partition" method.