### PR TITLE
Add a GetVolumeBounds rpc for estimating size

### DIFF
--- a/cognite/seismic/protos/v1/seismic_service.proto
+++ b/cognite/seismic/protos/v1/seismic_service.proto
@@ -114,6 +114,8 @@ service SeismicAPI {
      */
     rpc GetVolume(VolumeRequest) returns (stream com.cognite.seismic.Trace) {}
 
+    rpc GetVolumeBounds(VolumeRequest) returns (VolumeBoundsResponse) {}
+
     /**
      * Fetch seismic data in SEG-Y format.
      * The stream of responses each contain a byte array that must be written sequentially to a

--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -206,7 +206,9 @@ message GeometryBasedVolume {
 message VolumeBoundsResponse {
     int32 trace_size_bytes = 1; // The size in bytes of one Trace message
     int32 num_traces = 2;       // The number of traces returned
-    LineBasedVolume bounds = 3; // Upper and lower bounds and step sizes in each direction for the returned traces.
+    // Upper and lower bounds and step sizes in each direction for the returned traces.
+    // Null if the result is empty. The iline and xline fields will be null for a line-like geometry.
+    LineBasedVolume bounds = 3; 
 }
 
 message SegYSeismicRequest {

--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -204,9 +204,9 @@ message GeometryBasedVolume {
 }
 
 message VolumeBoundsResponse {
-    int32 total_size_bytes = 1;
-    int32 num_traces = 2;
-    LineBasedVolume bounds = 3;
+    int32 trace_size_bytes = 1; // The size in bytes of one Trace message
+    int32 num_traces = 2;       // The number of traces returned
+    LineBasedVolume bounds = 3; // Upper and lower bounds and step sizes in each direction for the returned traces.
 }
 
 message SegYSeismicRequest {

--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -203,6 +203,12 @@ message GeometryBasedVolume {
     LineDescriptor z_range = 3;
 }
 
+message VolumeBoundsResponse {
+    int32 total_size = 1;
+    int32 num_traces = 2;
+    LineBasedVolume bounds = 3;
+}
+
 message SegYSeismicRequest {
     oneof identifier {
         Identifier seismic = 1;

--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -204,7 +204,7 @@ message GeometryBasedVolume {
 }
 
 message VolumeBoundsResponse {
-    int32 total_size_kilobytes = 1;
+    int32 total_size_bytes = 1;
     int32 num_traces = 2;
     LineBasedVolume bounds = 3;
 }

--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -204,7 +204,7 @@ message GeometryBasedVolume {
 }
 
 message VolumeBoundsResponse {
-    int32 total_size = 1;
+    int32 total_size_kilobytes = 1;
     int32 num_traces = 2;
     LineBasedVolume bounds = 3;
 }

--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -206,9 +206,10 @@ message GeometryBasedVolume {
 message VolumeBoundsResponse {
     int32 trace_size_bytes = 1; // The size in bytes of one Trace message
     int32 num_traces = 2;       // The number of traces returned
+    string crs = 3;             // CRS of the returned trace coordinates
     // Upper and lower bounds and step sizes in each direction for the returned traces.
     // Null if the result is empty. The iline and xline fields will be null for a line-like geometry.
-    LineBasedVolume bounds = 3; 
+    LineBasedVolume bounds = 4;
 }
 
 message SegYSeismicRequest {


### PR DESCRIPTION
When supporting geometry queries in the V1 API, we'll want to compute
the total size of returned traces (for `volume_seismic.get_volume_size`)
as well as the min, max, step encompassing all inlines and xlines (for
finding proper array sizes in `volume_seismic.get_array`). This is
doable from just the volume def with line-based queries, but not with
spatial queries. So instead of adding more and more code duplication to
the sdk, perform the computation on the server side with a new rpc.