### PR TITLE
V1 Search jobs - Multiple filters

### DIFF
--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -249,7 +249,7 @@ message SearchJobStatusRequest {
         }
     }
 
-    Filter filter = 1;
+    repeated Filter filter = 1;
 }
 
 message JobStatusResponse {

--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -250,7 +250,7 @@ message SearchJobStatusRequest {
     }
 
     // Used to remove jobs from the returned stream that do not satisfy *all* of the given constraints.
-    // Note that only one of each filter variant may be applied. For example, attempting to jobs that passed *or* failed will be invalid.
+    // Note that only one of each filter variant may be applied. For example, attempting to find jobs that passed *or* failed will be invalid.
     repeated Filter filters = 1;
 }
 

--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -249,6 +249,8 @@ message SearchJobStatusRequest {
         }
     }
 
+    // Used to remove jobs from the returned stream that do not satisfy *all* of the given constraints.
+    // Note that only one of each filter variant may be applied. For example, attempting to jobs that passed *or* failed will be invalid.
     repeated Filter filter = 1;
 }
 

--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -251,7 +251,7 @@ message SearchJobStatusRequest {
 
     // Used to remove jobs from the returned stream that do not satisfy *all* of the given constraints.
     // Note that only one of each filter variant may be applied. For example, attempting to jobs that passed *or* failed will be invalid.
-    repeated Filter filter = 1;
+    repeated Filter filters = 1;
 }
 
 message JobStatusResponse {

--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -230,28 +230,16 @@ message SearchFilesRequest {
 }
 
 message SearchJobStatusRequest {
-    message Filter {
-        message Id {
-            oneof id {
-                string job_id = 1;
-                string file_uuid = 2;
-            }
-        }
-
-        oneof filter {
-            Id id = 1;
-            JobStatus status = 2;
-            string target_storage_tier_name = 3;
-            google.protobuf.Timestamp started_before = 4;
-            google.protobuf.Timestamp started_after = 5;
-            google.protobuf.Timestamp updated_before = 6;
-            google.protobuf.Timestamp updated_after = 7;
-        }
+    oneof id {
+        string job_id = 1;
+        string file_uuid = 2;
     }
-
-    // Used to remove jobs from the returned stream that do not satisfy *all* of the given constraints.
-    // Note that only one of each filter variant may be applied. For example, attempting to find jobs that passed *or* failed will be invalid.
-    repeated Filter filters = 1;
+    JobStatus status = 3;
+    google.protobuf.StringValue target_storage_tier_name = 4;
+    google.protobuf.Timestamp started_before = 5;
+    google.protobuf.Timestamp started_after = 6;
+    google.protobuf.Timestamp updated_before = 7;
+    google.protobuf.Timestamp updated_after = 8;
 }
 
 message JobStatusResponse {


### PR DESCRIPTION
Currently trying to search for "failed jobs", for example, returns a ton of jobs which can be a bit overwhelming when you might only want the ones from the last 2 days. Supporting at most one of each filter seems reasonable.