### PR TITLE
Update the Dimensions protobuf

### DIFF
--- a/cognite/seismic/protos/types.proto
+++ b/cognite/seismic/protos/types.proto
@@ -279,6 +279,7 @@ enum IngestionSource {
 }
 
 enum Dimensions {
-    TWO_DEE = 0;
-    THREE_DEE = 1;
+    UNSPECIFIED = 0;
+    TWO_DEE = 2;
+    THREE_DEE = 3;
 }


### PR DESCRIPTION
Add an unspecified value for compatibility/transition phases, and renumber the twodee/threedee just ... because. :p 

This should be unused yet, so it's not too late.