### PR TITLE
Convey 2D offsets and trace headers in file registration

### DIFF
--- a/cognite/seismic/protos/ingest_service_messages.proto
+++ b/cognite/seismic/protos/ingest_service_messages.proto
@@ -49,9 +49,6 @@ message RegisterFileRequest {
     google.protobuf.Int32Value crossline_offset = 8;                // [optional] Crossline number field in the trace headers. Defaults to 193 as per the SEG-Y rev1 specification
     google.protobuf.Int32Value cdp_x_offset = 9;                    // [optional] X coordinate of ensemble (CDP) position in trace headers. Defaults to 181 as per the SEG-Y rev1 specification
     google.protobuf.Int32Value cdp_y_offset = 10;                   // [optional] Y coordinate of ensemble (CDP) position in trace headers. Defaults to 185 as per the SEG-Y rev1 specification
-    google.protobuf.Int32Value cdp_offset = 15;                     // [optional] Ensemble (CDP) position in trace headers. Defaults to 21 as per the SEG-Y rev1 specification
-    google.protobuf.Int32Value energy_source_point_offset = 16;     // [optional] Energy source point position in trace headers. Defaults to 17 as per the SEG-Y rev1 specification
-    google.protobuf.Int32Value poststack_2d_offset = 17;            // [optional] Shotpoint for 2D poststack position in trace headers. Defaults to 197 as per the SEG-Y rev1 specification
     ExternalId external_id = 11;                                    // [optional] An external identifier - matches service contract field
     /**
     [optional] Multiplier for CDP-X and CDP-Y values, overrides scalar factor obtained from trace header.
@@ -62,7 +59,10 @@ message RegisterFileRequest {
     **/
     google.protobuf.FloatValue source_group_scalar_override = 12;
     Dimensions dimensions = 13;                                     // [required] File data dimensionality, either 2D or 3D
-    repeated TraceHeaderField trace_header_key = 14;                // [required for 2D seismics] The trace header fields that will be used as keys for indexing.
+    google.protobuf.Int32Value cdp_offset = 14;                     // [optional] Ensemble (CDP) position in trace headers. Defaults to 21 as per the SEG-Y rev1 specification
+    google.protobuf.Int32Value energy_source_point_offset = 15;     // [optional] Energy source point position in trace headers. Defaults to 17 as per the SEG-Y rev1 specification
+    google.protobuf.Int32Value poststack_2d_offset = 16;            // [optional] Shotpoint for 2D poststack position in trace headers. Defaults to 197 as per the SEG-Y rev1 specification
+    repeated TraceHeaderField trace_header_key = 17;                // [required for 2D seismics] The trace header fields that will be used as keys for indexing.
 }
 
 message RegisterFileResponse {
@@ -217,6 +217,9 @@ message EditFileRequest {
     The next ingestion processing of a file will then use the source group scalar values found in trace headers.
     **/
     google.protobuf.FloatValue source_group_scalar_override = 11;
+    google.protobuf.Int32Value cdp_offset = 12;                     // [optional] Ensemble (CDP) position in trace headers. Defaults to 21 as per the SEG-Y rev1 specification
+    google.protobuf.Int32Value energy_source_point_offset = 13;     // [optional] Energy source point position in trace headers. Defaults to 17 as per the SEG-Y rev1 specification
+    google.protobuf.Int32Value poststack_2d_offset = 14;            // [optional] Shotpoint for 2D poststack position in trace headers. Defaults to 197 as per the SEG-Y rev1 specification
 }
 
 message EditFileResponse {
@@ -228,6 +231,9 @@ message EditFileResponse {
     google.protobuf.Int32Value cdp_x_offset = 6;                    // [optional] X coordinate of ensemble (CDP) position in trace headers. Defaults to 181 as per the SEG-Y rev1 specification
     google.protobuf.Int32Value cdp_y_offset = 7;                    // [optional] Y coordinate of ensemble (CDP) position in trace headers. Defaults to 185 as per the SEG-Y rev1 specification
     google.protobuf.FloatValue source_group_scalar_override = 8;    // [optional] Multiplier for CDP-X and CDP-Y values, overrides scalar factor obtained from trace header
+    google.protobuf.Int32Value cdp_offset = 9;                      // [optional] Ensemble (CDP) position in trace headers. Defaults to 21 as per the SEG-Y rev1 specification
+    google.protobuf.Int32Value energy_source_point_offset = 10;     // [optional] Energy source point position in trace headers. Defaults to 17 as per the SEG-Y rev1 specification
+    google.protobuf.Int32Value poststack_2d_offset = 11;            // [optional] Shotpoint for 2D poststack position in trace headers. Defaults to 197 as per the SEG-Y rev1 specification
 }
 
 // -----

--- a/cognite/seismic/protos/ingest_service_messages.proto
+++ b/cognite/seismic/protos/ingest_service_messages.proto
@@ -15,10 +15,10 @@ import "google/protobuf/wrappers.proto";
     {"name": "surveyname", "metadata": {"location": "underwater"}, "external_id": "surveyname-external" }
 **/
 message RegisterSurveyRequest {
-    string name = 1;                  // [required]
-    map<string, string> metadata = 2; // [optional]
-    ExternalId external_id = 3;       // [optional]
-    CRS crs = 4;                   // [optional] new CRS used by all members
+    string name = 1;                                  // [required]
+    map<string, string> metadata = 2;                 // [optional]
+    ExternalId external_id = 3;                       // [optional]
+    CRS crs = 4;                                      // [optional] new CRS used by all members
     SurveyGridTransformation grid_transformation = 5; // [optional] Affine transformation from grid bins to coordinates
     CustomSurveyCoverage custom_coverage = 6;
 }
@@ -49,6 +49,9 @@ message RegisterFileRequest {
     google.protobuf.Int32Value crossline_offset = 8;                // [optional] Crossline number field in the trace headers. Defaults to 193 as per the SEG-Y rev1 specification
     google.protobuf.Int32Value cdp_x_offset = 9;                    // [optional] X coordinate of ensemble (CDP) position in trace headers. Defaults to 181 as per the SEG-Y rev1 specification
     google.protobuf.Int32Value cdp_y_offset = 10;                   // [optional] Y coordinate of ensemble (CDP) position in trace headers. Defaults to 185 as per the SEG-Y rev1 specification
+    google.protobuf.Int32Value cdp_offset = 15;                     // [optional] Ensemble (CDP) position in trace headers. Defaults to 21 as per the SEG-Y rev1 specification
+    google.protobuf.Int32Value energy_source_point_offset = 16;     // [optional] Energy source point position in trace headers. Defaults to 17 as per the SEG-Y rev1 specification
+    google.protobuf.Int32Value poststack_2d_offset = 17;            // [optional] Shotpoint for 2D poststack position in trace headers. Defaults to 197 as per the SEG-Y rev1 specification
     ExternalId external_id = 11;                                    // [optional] An external identifier - matches service contract field
     /**
     [optional] Multiplier for CDP-X and CDP-Y values, overrides scalar factor obtained from trace header.
@@ -59,6 +62,7 @@ message RegisterFileRequest {
     **/
     google.protobuf.FloatValue source_group_scalar_override = 12;
     Dimensions dimensions = 13;                                     // [required] File data dimensionality, either 2D or 3D
+    repeated TraceHeaderField trace_header_key = 14;                // [required for 2D seismics] The trace header fields that will be used as keys for indexing.
 }
 
 message RegisterFileResponse {

--- a/cognite/seismic/protos/ingest_service_messages.proto
+++ b/cognite/seismic/protos/ingest_service_messages.proto
@@ -62,7 +62,7 @@ message RegisterFileRequest {
     google.protobuf.Int32Value cdp_offset = 14;                     // [optional] Ensemble (CDP) position in trace headers. Defaults to 21 as per the SEG-Y rev1 specification
     google.protobuf.Int32Value energy_source_point_offset = 15;     // [optional] Energy source point position in trace headers. Defaults to 17 as per the SEG-Y rev1 specification
     google.protobuf.Int32Value poststack_2d_offset = 16;            // [optional] Shotpoint for 2D poststack position in trace headers. Defaults to 197 as per the SEG-Y rev1 specification
-    repeated TraceHeaderField trace_header_key = 17;                // [required for 2D seismics] The trace header fields that will be used as keys for indexing.
+    repeated TraceHeaderField trace_header_fields = 17;             // [required for 2D seismics] The trace header fields that will be used as keys for indexing.
 }
 
 message RegisterFileResponse {

--- a/cognite/seismic/protos/ingest_service_messages.proto
+++ b/cognite/seismic/protos/ingest_service_messages.proto
@@ -61,7 +61,7 @@ message RegisterFileRequest {
     Dimensions dimensions = 13;                                     // [required] File data dimensionality, either 2D or 3D
     google.protobuf.Int32Value cdp_offset = 14;                     // [optional] Ensemble (CDP) position in trace headers. Defaults to 21 as per the SEG-Y rev1 specification
     google.protobuf.Int32Value energy_source_point_offset = 15;     // [optional] Energy source point position in trace headers. Defaults to 17 as per the SEG-Y rev1 specification
-    google.protobuf.Int32Value poststack_2d_shotpoint_offset = 16;  // [optional] Shotpoint for 2D poststack position in trace headers. Defaults to 197 as per the SEG-Y rev1 specification
+    google.protobuf.Int32Value shotpoint_offset = 16;               // [optional] Shotpoint for position in trace headers. Defaults to 197 as per the SEG-Y rev1 specification
     repeated TraceHeaderField trace_header_fields = 17;             // [required for 2D seismics] The trace header fields that will be used as keys for indexing.
 }
 
@@ -219,7 +219,7 @@ message EditFileRequest {
     google.protobuf.FloatValue source_group_scalar_override = 11;
     google.protobuf.Int32Value cdp_offset = 12;                     // [optional] Ensemble (CDP) position in trace headers. Defaults to 21 as per the SEG-Y rev1 specification
     google.protobuf.Int32Value energy_source_point_offset = 13;     // [optional] Energy source point position in trace headers. Defaults to 17 as per the SEG-Y rev1 specification
-    google.protobuf.Int32Value poststack_2d_shotpoint_offset = 14;  // [optional] Shotpoint for 2D poststack position in trace headers. Defaults to 197 as per the SEG-Y rev1 specification
+    google.protobuf.Int32Value shotpoint_offset = 14;               // [optional] Shotpoint position in trace headers. Defaults to 197 as per the SEG-Y rev1 specification
 }
 
 message EditFileResponse {
@@ -233,7 +233,7 @@ message EditFileResponse {
     google.protobuf.FloatValue source_group_scalar_override = 8;    // [optional] Multiplier for CDP-X and CDP-Y values, overrides scalar factor obtained from trace header
     google.protobuf.Int32Value cdp_offset = 9;                      // [optional] Ensemble (CDP) position in trace headers. Defaults to 21 as per the SEG-Y rev1 specification
     google.protobuf.Int32Value energy_source_point_offset = 10;     // [optional] Energy source point position in trace headers. Defaults to 17 as per the SEG-Y rev1 specification
-    google.protobuf.Int32Value poststack_2d_shotpoint_offset = 11; // [optional] Shotpoint for 2D poststack position in trace headers. Defaults to 197 as per the SEG-Y rev1 specification
+    google.protobuf.Int32Value shotpoint_offset = 11;               // [optional] Shotpoint position in trace headers. Defaults to 197 as per the SEG-Y rev1 specification
 }
 
 // -----

--- a/cognite/seismic/protos/ingest_service_messages.proto
+++ b/cognite/seismic/protos/ingest_service_messages.proto
@@ -61,7 +61,7 @@ message RegisterFileRequest {
     Dimensions dimensions = 13;                                     // [required] File data dimensionality, either 2D or 3D
     google.protobuf.Int32Value cdp_offset = 14;                     // [optional] Ensemble (CDP) position in trace headers. Defaults to 21 as per the SEG-Y rev1 specification
     google.protobuf.Int32Value energy_source_point_offset = 15;     // [optional] Energy source point position in trace headers. Defaults to 17 as per the SEG-Y rev1 specification
-    google.protobuf.Int32Value poststack_2d_offset = 16;            // [optional] Shotpoint for 2D poststack position in trace headers. Defaults to 197 as per the SEG-Y rev1 specification
+    google.protobuf.Int32Value poststack_2d_shotpoint_offset = 16;  // [optional] Shotpoint for 2D poststack position in trace headers. Defaults to 197 as per the SEG-Y rev1 specification
     repeated TraceHeaderField trace_header_fields = 17;             // [required for 2D seismics] The trace header fields that will be used as keys for indexing.
 }
 
@@ -219,7 +219,7 @@ message EditFileRequest {
     google.protobuf.FloatValue source_group_scalar_override = 11;
     google.protobuf.Int32Value cdp_offset = 12;                     // [optional] Ensemble (CDP) position in trace headers. Defaults to 21 as per the SEG-Y rev1 specification
     google.protobuf.Int32Value energy_source_point_offset = 13;     // [optional] Energy source point position in trace headers. Defaults to 17 as per the SEG-Y rev1 specification
-    google.protobuf.Int32Value poststack_2d_offset = 14;            // [optional] Shotpoint for 2D poststack position in trace headers. Defaults to 197 as per the SEG-Y rev1 specification
+    google.protobuf.Int32Value poststack_2d_shotpoint_offset = 14;  // [optional] Shotpoint for 2D poststack position in trace headers. Defaults to 197 as per the SEG-Y rev1 specification
 }
 
 message EditFileResponse {
@@ -233,7 +233,7 @@ message EditFileResponse {
     google.protobuf.FloatValue source_group_scalar_override = 8;    // [optional] Multiplier for CDP-X and CDP-Y values, overrides scalar factor obtained from trace header
     google.protobuf.Int32Value cdp_offset = 9;                      // [optional] Ensemble (CDP) position in trace headers. Defaults to 21 as per the SEG-Y rev1 specification
     google.protobuf.Int32Value energy_source_point_offset = 10;     // [optional] Energy source point position in trace headers. Defaults to 17 as per the SEG-Y rev1 specification
-    google.protobuf.Int32Value poststack_2d_offset = 11;            // [optional] Shotpoint for 2D poststack position in trace headers. Defaults to 197 as per the SEG-Y rev1 specification
+    google.protobuf.Int32Value poststack_2d_shotpoint_offset = 11; // [optional] Shotpoint for 2D poststack position in trace headers. Defaults to 197 as per the SEG-Y rev1 specification
 }
 
 // -----

--- a/cognite/seismic/protos/ingest_service_messages.proto
+++ b/cognite/seismic/protos/ingest_service_messages.proto
@@ -15,10 +15,10 @@ import "google/protobuf/wrappers.proto";
     {"name": "surveyname", "metadata": {"location": "underwater"}, "external_id": "surveyname-external" }
 **/
 message RegisterSurveyRequest {
-    string name = 1;                                  // [required]
-    map<string, string> metadata = 2;                 // [optional]
-    ExternalId external_id = 3;                       // [optional]
-    CRS crs = 4;                                      // [optional] new CRS used by all members
+    string name = 1;                  // [required]
+    map<string, string> metadata = 2; // [optional]
+    ExternalId external_id = 3;       // [optional]
+    CRS crs = 4;                   // [optional] new CRS used by all members
     SurveyGridTransformation grid_transformation = 5; // [optional] Affine transformation from grid bins to coordinates
     CustomSurveyCoverage custom_coverage = 6;
 }
@@ -59,10 +59,6 @@ message RegisterFileRequest {
     **/
     google.protobuf.FloatValue source_group_scalar_override = 12;
     Dimensions dimensions = 13;                                     // [required] File data dimensionality, either 2D or 3D
-    google.protobuf.Int32Value cdp_offset = 14;                     // [optional] Ensemble (CDP) position in trace headers. Defaults to 21 as per the SEG-Y rev1 specification
-    google.protobuf.Int32Value energy_source_point_offset = 15;     // [optional] Energy source point position in trace headers. Defaults to 17 as per the SEG-Y rev1 specification
-    google.protobuf.Int32Value shotpoint_offset = 16;               // [optional] Shotpoint for position in trace headers. Defaults to 197 as per the SEG-Y rev1 specification
-    repeated TraceHeaderField trace_header_fields = 17;             // [required for 2D seismics] The trace header fields that will be used as keys for indexing.
 }
 
 message RegisterFileResponse {
@@ -217,9 +213,6 @@ message EditFileRequest {
     The next ingestion processing of a file will then use the source group scalar values found in trace headers.
     **/
     google.protobuf.FloatValue source_group_scalar_override = 11;
-    google.protobuf.Int32Value cdp_offset = 12;                     // [optional] Ensemble (CDP) position in trace headers. Defaults to 21 as per the SEG-Y rev1 specification
-    google.protobuf.Int32Value energy_source_point_offset = 13;     // [optional] Energy source point position in trace headers. Defaults to 17 as per the SEG-Y rev1 specification
-    google.protobuf.Int32Value shotpoint_offset = 14;               // [optional] Shotpoint position in trace headers. Defaults to 197 as per the SEG-Y rev1 specification
 }
 
 message EditFileResponse {
@@ -231,9 +224,6 @@ message EditFileResponse {
     google.protobuf.Int32Value cdp_x_offset = 6;                    // [optional] X coordinate of ensemble (CDP) position in trace headers. Defaults to 181 as per the SEG-Y rev1 specification
     google.protobuf.Int32Value cdp_y_offset = 7;                    // [optional] Y coordinate of ensemble (CDP) position in trace headers. Defaults to 185 as per the SEG-Y rev1 specification
     google.protobuf.FloatValue source_group_scalar_override = 8;    // [optional] Multiplier for CDP-X and CDP-Y values, overrides scalar factor obtained from trace header
-    google.protobuf.Int32Value cdp_offset = 9;                      // [optional] Ensemble (CDP) position in trace headers. Defaults to 21 as per the SEG-Y rev1 specification
-    google.protobuf.Int32Value energy_source_point_offset = 10;     // [optional] Energy source point position in trace headers. Defaults to 17 as per the SEG-Y rev1 specification
-    google.protobuf.Int32Value shotpoint_offset = 11;               // [optional] Shotpoint position in trace headers. Defaults to 197 as per the SEG-Y rev1 specification
 }
 
 // -----

--- a/cognite/seismic/protos/types.proto
+++ b/cognite/seismic/protos/types.proto
@@ -279,13 +279,13 @@ enum IngestionSource {
 }
 
 enum Dimensions {
-    UNSPECIFIED = 0;
+    UNSPECIFIED_DIMENSION = 0;
     TWO_DEE = 2;
     THREE_DEE = 3;
 }
 
 enum TraceHeaderField {
-    UNSPECIFIED = 0;
+    UNSPECIFIED_TRACE_HEADER_FIELD = 0;
     ENERGY_SOURCE_POINT = 1;
     CDP = 2;
     INLINE = 3;

--- a/cognite/seismic/protos/types.proto
+++ b/cognite/seismic/protos/types.proto
@@ -285,9 +285,10 @@ enum Dimensions {
 }
 
 enum TraceHeaderField {
-    ENERGY_SOURCE_POINT = 0;
-    CDP = 1;
-    POST_STACK_2D_SHOTPOINT = 2;
+    UNSPECIFIED = 0;
+    ENERGY_SOURCE_POINT = 1;
+    CDP = 2;
     INLINE = 3;
     CROSSLINE = 4;
+    POST_STACK_2D_SHOTPOINT = 5;
 }

--- a/cognite/seismic/protos/types.proto
+++ b/cognite/seismic/protos/types.proto
@@ -290,5 +290,5 @@ enum TraceHeaderField {
     CDP = 2;
     INLINE = 3;
     CROSSLINE = 4;
-    POST_STACK_2D_SHOTPOINT = 5;
+    SHOTPOINT = 5;
 }

--- a/cognite/seismic/protos/types.proto
+++ b/cognite/seismic/protos/types.proto
@@ -283,3 +283,11 @@ enum Dimensions {
     TWO_DEE = 2;
     THREE_DEE = 3;
 }
+
+enum TraceHeaderField {
+    ENERGY_SOURCE_POINT = 0;
+    CDP = 1;
+    POST_STACK_2D_SHOTPOINT = 2;
+    INLINE = 3;
+    CROSSLINE = 4;
+}

--- a/cognite/seismic/protos/v1/seismic_service.proto
+++ b/cognite/seismic/protos/v1/seismic_service.proto
@@ -48,6 +48,21 @@ service SeismicAPI {
     rpc DeleteSurvey(DeleteSurveyRequest) returns (DeleteSurveyResponse) {}
 
     /**
+     * Registers a new file in a (previously registered) survey as source for ingestion.
+     */
+    rpc RegisterSourceSegyFile (RegisterSourceSegyFileRequest) returns (RegisterSourceSegyFileResponse) {}
+
+    /**
+     * Edits a registered source file.
+     */
+    rpc EditSourceSegyFile (EditSourceSegyFileRequest) returns (EditSourceSegyFileResponse) {}
+
+    /**
+     * Unregisters a file previously registered as source for ingestion.
+     */
+    rpc UnregisterSourceSegyFile (UnregisterSourceSegyFileRequest) returns (UnregisterSourceSegyFileResponse) {}
+
+    /**
      * Create new Seismics and assign them to partitions.
      * Seismics are mostly immutable save for their name and metadata. The user needs to delete an existing cutout and create a new one
      * if e.g. the definition or the seismic store must be changed

--- a/cognite/seismic/protos/v1/seismic_service.proto
+++ b/cognite/seismic/protos/v1/seismic_service.proto
@@ -54,11 +54,19 @@ service SeismicAPI {
 
     /**
      * Edits a registered source file.
+     *
+     * Before editing, there must be no ingestion jobs running for the source file and, if already ingested, any SeismicStore associated
+     * with the source file must be deleted.
+     * This request will fail if the above criteira are not met.
      */
     rpc EditSourceSegyFile (EditSourceSegyFileRequest) returns (EditSourceSegyFileResponse) {}
 
     /**
      * Unregisters a file previously registered as source for ingestion.
+     *
+     * Before unregistering, there must be no ingestion jobs running for the source file and, if already ingested, any SeismicStore associated
+     * with the source file must be deleted.
+     * This request will fail if the above criteira are not met.
      */
     rpc UnregisterSourceSegyFile (UnregisterSourceSegyFileRequest) returns (UnregisterSourceSegyFileResponse) {}
 

--- a/cognite/seismic/protos/v1/seismic_service_datatypes.proto
+++ b/cognite/seismic/protos/v1/seismic_service_datatypes.proto
@@ -53,13 +53,13 @@ message SourceSegyFile {
 
 // Metadata related to interpreting SEG-Y files.
 message SegyOverrides {
-    google.protobuf.Int32Value inline_offset = 1;                  // Inline number field in the trace headers. Defaults to 189 as per the SEG-Y rev1 specification
-    google.protobuf.Int32Value crossline_offset = 2;               // Crossline number field in the trace headers. Defaults to 193 as per the SEG-Y rev1 specification
-    google.protobuf.Int32Value cdp_x_offset = 3;                   // X coordinate of ensemble (CDP) position in trace headers. Defaults to 181 as per the SEG-Y rev1 specification
-    google.protobuf.Int32Value cdp_y_offset = 4;                   // Y coordinate of ensemble (CDP) position in trace headers. Defaults to 185 as per the SEG-Y rev1 specification
-    google.protobuf.Int32Value cdp_number_offset = 6;              // Ensemble (CDP) position in trace headers. Defaults to 21 as per the SEG-Y rev1 specification
-    google.protobuf.Int32Value energy_source_point_offset = 7;     // Energy source point position in trace headers. Defaults to 17 as per the SEG-Y rev1 specification
-    google.protobuf.Int32Value shotpoint_offset = 8;               // Shotpoint position in trace headers. Defaults to 197 as per the SEG-Y rev1 specification
+    google.protobuf.Int32Value inline_offset = 1;                  // Position of the inline number field in the trace headers. Defaults to 189 as per the SEG-Y rev1 specification
+    google.protobuf.Int32Value crossline_offset = 2;               // Position of the crossline number field in the trace headers. Defaults to 193 as per the SEG-Y rev1 specification
+    google.protobuf.Int32Value cdp_x_offset = 3;                   // Position of the X coordinate of ensemble (CDP) in trace headers. Defaults to 181 as per the SEG-Y rev1 specification
+    google.protobuf.Int32Value cdp_y_offset = 4;                   // Position of the Y coordinate of ensemble (CDP) in trace headers. Defaults to 185 as per the SEG-Y rev1 specification
+    google.protobuf.Int32Value cdp_number_offset = 6;              // Position of the ensemble (CDP) number in trace headers. Defaults to 21 as per the SEG-Y rev1 specification
+    google.protobuf.Int32Value energy_source_point_offset = 7;     // Position of the energy source point in trace headers. Defaults to 17 as per the SEG-Y rev1 specification
+    google.protobuf.Int32Value shotpoint_offset = 8;               // Position of the shotpoint field in trace headers. Defaults to 197 as per the SEG-Y rev1 specification
 
     /**
     [optional] Multiplier for CDP-X and CDP-Y values, overrides scalar factor obtained from trace header.

--- a/cognite/seismic/protos/v1/seismic_service_datatypes.proto
+++ b/cognite/seismic/protos/v1/seismic_service_datatypes.proto
@@ -58,7 +58,7 @@ message SegyOverrides {
     google.protobuf.Int32Value cdp_y_offset = 4;                   // Y coordinate of ensemble (CDP) position in trace headers. Defaults to 185 as per the SEG-Y rev1 specification
     google.protobuf.Int32Value cdp_offset = 6;                     // Ensemble (CDP) position in trace headers. Defaults to 21 as per the SEG-Y rev1 specification
     google.protobuf.Int32Value energy_source_point_offset = 7;     // Energy source point position in trace headers. Defaults to 17 as per the SEG-Y rev1 specification
-    google.protobuf.Int32Value poststack_2d_shotpoint_offset = 8;  // Shotpoint for 2D poststack position in trace headers. Defaults to 197 as per the SEG-Y rev1 specification
+    google.protobuf.Int32Value shotpoint_offset = 8;               // Shotpoint position in trace headers. Defaults to 197 as per the SEG-Y rev1 specification
 
     /**
     [optional] Multiplier for CDP-X and CDP-Y values, overrides scalar factor obtained from trace header.

--- a/cognite/seismic/protos/v1/seismic_service_datatypes.proto
+++ b/cognite/seismic/protos/v1/seismic_service_datatypes.proto
@@ -52,10 +52,13 @@ message SourceSegyFile {
 
 // Metadata related to interpreting SEG-Y files.
 message SegyOverrides {
-    google.protobuf.Int32Value inline_offset = 1; // Inline number field in the trace headers. Defaults to 189 as per the SEG-Y rev1 specification
-    google.protobuf.Int32Value crossline_offset = 2; // Crossline number field in the trace headers. Defaults to 193 as per the SEG-Y rev1 specification
-    google.protobuf.Int32Value cdp_x_offset = 3; // X coordinate of ensemble (CDP) position in trace headers. Defaults to 181 as per the SEG-Y rev1 specification
-    google.protobuf.Int32Value cdp_y_offset = 4; // Y coordinate of ensemble (CDP) position in trace headers. Defaults to 185 as per the SEG-Y rev1 specification
+    google.protobuf.Int32Value inline_offset = 1;                  // Inline number field in the trace headers. Defaults to 189 as per the SEG-Y rev1 specification
+    google.protobuf.Int32Value crossline_offset = 2;               // Crossline number field in the trace headers. Defaults to 193 as per the SEG-Y rev1 specification
+    google.protobuf.Int32Value cdp_x_offset = 3;                   // X coordinate of ensemble (CDP) position in trace headers. Defaults to 181 as per the SEG-Y rev1 specification
+    google.protobuf.Int32Value cdp_y_offset = 4;                   // Y coordinate of ensemble (CDP) position in trace headers. Defaults to 185 as per the SEG-Y rev1 specification
+    google.protobuf.Int32Value cdp_offset = 6;                     // Ensemble (CDP) position in trace headers. Defaults to 21 as per the SEG-Y rev1 specification
+    google.protobuf.Int32Value energy_source_point_offset = 7;     // Energy source point position in trace headers. Defaults to 17 as per the SEG-Y rev1 specification
+    google.protobuf.Int32Value poststack_2d_offset = 8;            // Shotpoint for 2D poststack position in trace headers. Defaults to 197 as per the SEG-Y rev1 specification
 
     /**
     [optional] Multiplier for CDP-X and CDP-Y values, overrides scalar factor obtained from trace header.

--- a/cognite/seismic/protos/v1/seismic_service_datatypes.proto
+++ b/cognite/seismic/protos/v1/seismic_service_datatypes.proto
@@ -48,6 +48,7 @@ message SourceSegyFile {
     string cloud_storage_path = 7; // The cloud storage path for the file, excluding the file name
     map<string, string> metadata = 5;
     SegyOverrides segy_overrides = 6;
+    repeated TraceHeaderField trace_header_fields = 8; // The trace header fields that will be used as keys for indexing.
 }
 
 // Metadata related to interpreting SEG-Y files.

--- a/cognite/seismic/protos/v1/seismic_service_datatypes.proto
+++ b/cognite/seismic/protos/v1/seismic_service_datatypes.proto
@@ -58,7 +58,7 @@ message SegyOverrides {
     google.protobuf.Int32Value cdp_y_offset = 4;                   // Y coordinate of ensemble (CDP) position in trace headers. Defaults to 185 as per the SEG-Y rev1 specification
     google.protobuf.Int32Value cdp_offset = 6;                     // Ensemble (CDP) position in trace headers. Defaults to 21 as per the SEG-Y rev1 specification
     google.protobuf.Int32Value energy_source_point_offset = 7;     // Energy source point position in trace headers. Defaults to 17 as per the SEG-Y rev1 specification
-    google.protobuf.Int32Value poststack_2d_offset = 8;            // Shotpoint for 2D poststack position in trace headers. Defaults to 197 as per the SEG-Y rev1 specification
+    google.protobuf.Int32Value poststack_2d_shotpoint_offset = 8;  // Shotpoint for 2D poststack position in trace headers. Defaults to 197 as per the SEG-Y rev1 specification
 
     /**
     [optional] Multiplier for CDP-X and CDP-Y values, overrides scalar factor obtained from trace header.

--- a/cognite/seismic/protos/v1/seismic_service_datatypes.proto
+++ b/cognite/seismic/protos/v1/seismic_service_datatypes.proto
@@ -57,7 +57,7 @@ message SegyOverrides {
     google.protobuf.Int32Value crossline_offset = 2;               // Crossline number field in the trace headers. Defaults to 193 as per the SEG-Y rev1 specification
     google.protobuf.Int32Value cdp_x_offset = 3;                   // X coordinate of ensemble (CDP) position in trace headers. Defaults to 181 as per the SEG-Y rev1 specification
     google.protobuf.Int32Value cdp_y_offset = 4;                   // Y coordinate of ensemble (CDP) position in trace headers. Defaults to 185 as per the SEG-Y rev1 specification
-    google.protobuf.Int32Value cdp_offset = 6;                     // Ensemble (CDP) position in trace headers. Defaults to 21 as per the SEG-Y rev1 specification
+    google.protobuf.Int32Value cdp_number_offset = 6;              // Ensemble (CDP) position in trace headers. Defaults to 21 as per the SEG-Y rev1 specification
     google.protobuf.Int32Value energy_source_point_offset = 7;     // Energy source point position in trace headers. Defaults to 17 as per the SEG-Y rev1 specification
     google.protobuf.Int32Value shotpoint_offset = 8;               // Shotpoint position in trace headers. Defaults to 197 as per the SEG-Y rev1 specification
 

--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -94,13 +94,14 @@ message RegisterSourceSegyFileResponse {
 
 message EditSourceSegyFileRequest {
     Identifier file = 1;                                // [required] The registered source file to edit
-    string path = 2;                                    // [required] Path including protocol, bucket and directory structure. Example: "gs://cognite-seismic-eu/samples/"
-    string name = 3;                                    // [required] Unique filename including extension. Example: "DN1302M03R16_MERGED_KPSDM_00-32_DEG_T.sgy". The name must be unique across buckets and can be used to identify this file in query requests
+    string path = 2;                                    // [optional] Path including protocol, bucket and directory structure. Example: "gs://cognite-seismic-eu/samples/"
+    string name = 3;                                    // [optional] Unique filename including extension. Example: "DN1302M03R16_MERGED_KPSDM_00-32_DEG_T.sgy". The name must be unique across buckets and can be used to identify this file in query requests
     ExternalId external_id = 4;                         // [optional] An external identifier - matches service contract field
     map<string, string> metadata = 5;                   // [optional] Any custom-defined metadata
-    CRS crs = 6;                                        // [required] Official name of the CRS used. Example: "EPSG:23031"
+    CRS crs = 6;                                        // [optional] Official name of the CRS used. Example: "EPSG:23031"
     SegyOverrides overrides = 7;                        // [optional] Overrides for the source file
     repeated TraceHeaderField trace_header_fields = 8;  // [optional] The trace header fields that will be used as keys for indexing
+    Dimensions dimensions = 9;                          // [optional] File data dimensionality, either 2D or 3D
 }
 
 message EditSourceSegyFileResponse {

--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -11,7 +11,7 @@ import "cognite/seismic/protos/types.proto";
 
 // ---
 
-// Iteration: 8 <- increment this number when you modify this file
+// Iteration: 9 <- increment this number when you modify this file
 // (╯°□°)╯︵ ┻━┻
 
 /**
@@ -78,14 +78,13 @@ message DeleteSurveyResponse {
 
 message RegisterSourceSegyFileRequest {
     Identifier survey = 1;                              // [required] The survey this source file belongs to
-    string path = 2;                                    // [required] Path including protocol, bucket and directory structure. Example: "gs://cognite-seismic-eu/samples/"
-    string name = 3;                                    // [required] Unique filename including extension. Example: "DN1302M03R16_MERGED_KPSDM_00-32_DEG_T.sgy". The name must be unique across buckets and can be used to identify this file in query requests
-    ExternalId external_id = 4;                         // [optional] An external identifier - matches service contract field
-    map<string, string> metadata = 5;                   // [optional] Any custom-defined metadata
-    CRS crs = 6;                                        // [required] Official name of the CRS used. Example: "EPSG:23031"
-    SegyOverrides overrides = 7;                        // [optional] Overrides for the source file
-    repeated TraceHeaderField trace_header_fields = 8;  // [optional] The trace header fields that will be used as keys for indexing
-    Dimensions dimensions = 9;                          // [required] File data dimensionality, either 2D or 3D
+    string path = 2;                                    // [required] Path including protocol, bucket, directory structure, and file name. Example: "gs://cognite-seismic-eu/samples/DN1302M03R16_MERGED_KPSDM_00-32_DEG_T.sgy"
+    ExternalId external_id = 3;                         // [optional] An external identifier - matches service contract field
+    map<string, string> metadata = 4;                   // [optional] Any custom-defined metadata
+    CRS crs = 5;                                        // [required] Official name of the CRS used. Example: "EPSG:23031"
+    SegyOverrides overrides = 6;                        // [optional] Overrides for the source file
+    repeated TraceHeaderField trace_header_fields = 7;  // [optional] The trace header fields that will be used as keys for indexing
+    Dimensions dimensions = 8;                          // [required] File data dimensionality, either 2D or 3D
 }
 
 message RegisterSourceSegyFileResponse {
@@ -94,14 +93,13 @@ message RegisterSourceSegyFileResponse {
 
 message EditSourceSegyFileRequest {
     Identifier file = 1;                                // [required] The registered source file to edit
-    string path = 2;                                    // [optional] Path including protocol, bucket and directory structure. Example: "gs://cognite-seismic-eu/samples/"
-    string name = 3;                                    // [optional] Unique filename including extension. Example: "DN1302M03R16_MERGED_KPSDM_00-32_DEG_T.sgy". The name must be unique across buckets and can be used to identify this file in query requests
-    ExternalId external_id = 4;                         // [optional] An external identifier - matches service contract field
-    map<string, string> metadata = 5;                   // [optional] Any custom-defined metadata
-    CRS crs = 6;                                        // [optional] Official name of the CRS used. Example: "EPSG:23031"
-    SegyOverrides overrides = 7;                        // [optional] Overrides for the source file
-    repeated TraceHeaderField trace_header_fields = 8;  // [optional] The trace header fields that will be used as keys for indexing
-    Dimensions dimensions = 9;                          // [optional] File data dimensionality, either 2D or 3D
+    google.protobuf.StringValue path = 2;               // [optional] Path including protocol, bucket, directory structure, and file name. Example: "gs://cognite-seismic-eu/samples/DN1302M03R16_MERGED_KPSDM_00-32_DEG_T.sgy"
+    ExternalId external_id = 3;                         // [optional] An external identifier - matches service contract field
+    map<string, string> metadata = 4;                   // [optional] Any custom-defined metadata
+    CRS crs = 5;                                        // [optional] Official name of the CRS used. Example: "EPSG:23031"
+    SegyOverrides overrides = 6;                        // [optional] Overrides for the source file
+    repeated TraceHeaderField trace_header_fields = 7;  // [optional] The trace header fields that will be used as keys for indexing
+    Dimensions dimensions = 8;                          // [optional] File data dimensionality, either 2D or 3D
 }
 
 message EditSourceSegyFileResponse {

--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -73,6 +73,51 @@ message DeleteSurveyResponse {
 }
 
 /**
+    Source Files
+**/
+
+message RegisterSourceSegyFileRequest {
+    Identifier survey = 1;                              // [required] The survey this source file belongs to
+    string path = 2;                                    // [required if file is not synthetic] Path including protocol, bucket and directory structure. Example: "gs://cognite-seismic-eu/samples/"
+    string name = 3;                                    // [required] Unique filename including extension. Example: "DN1302M03R16_MERGED_KPSDM_00-32_DEG_T.sgy". The name must be unique across buckets and can be used to identify this file in query requests
+    ExternalId external_id = 4;                         // [optional] An external identifier - matches service contract field
+    map<string, string> metadata = 5;                   // [optional] Any custom-defined metadata
+    CRS crs = 6;                                        // [required] Official name of the CRS used. Example: "EPSG:23031"
+    google.protobuf.BoolValue is_temporary = 7;         // [optional] Tells whether file is temporary (writeable) or not. False by default
+    SegyOverrides overrides = 8;                        // [optional] Overrides for the source file
+    Dimensions dimensions = 9;                          // [required] File data dimensionality, either 2D or 3D
+    repeated TraceHeaderField trace_header_fields = 10; // [optional] The trace header fields that will be used as keys for indexing.
+}
+
+message RegisterSourceSegyFileResponse {
+    SourceSegyFile file = 1;
+}
+
+message EditSourceSegyFileRequest {
+    Identifier file = 1;                                // [required] The registered source file to edit.
+    string path = 2;                                    // [required if file is not synthetic] Path including protocol, bucket and directory structure. Example: "gs://cognite-seismic-eu/samples/"
+    string name = 3;                                    // [required] Unique filename including extension. Example: "DN1302M03R16_MERGED_KPSDM_00-32_DEG_T.sgy". The name must be unique across buckets and can be used to identify this file in query requests
+    ExternalId external_id = 4;                         // [optional] An external identifier - matches service contract field
+    map<string, string> metadata = 5;                   // [optional] Any custom-defined metadata
+    CRS crs = 6;                                        // [required] Official name of the CRS used. Example: "EPSG:23031"
+    SegyOverrides overrides = 7;                        // [optional] Overrides for the source file
+    repeated TraceHeaderField trace_header_fields = 8;  // [optional] The trace header fields that will be used as keys for indexing.
+}
+
+message EditSourceSegyFileResponse {
+    SourceSegyFile file = 1;
+}
+
+message UnregisterSourceSegyFileRequest {
+    Identifier file = 1;                                // [required] The file unregister
+    bool keep_registered = 2;                           // [optional] Delete contents of file (undo the ingestion), but keep the file registered. Defaults to false
+}
+
+message UnregisterSourceSegyFileResponse {
+    int64 survey = 1;                                   // The survey the source file belong to
+}
+
+/**
     Seismics
 **/
 

--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -83,10 +83,9 @@ message RegisterSourceSegyFileRequest {
     ExternalId external_id = 4;                         // [optional] An external identifier - matches service contract field
     map<string, string> metadata = 5;                   // [optional] Any custom-defined metadata
     CRS crs = 6;                                        // [required] Official name of the CRS used. Example: "EPSG:23031"
-    google.protobuf.BoolValue is_temporary = 7;         // [optional] Tells whether file is temporary (writeable) or not. False by default
-    SegyOverrides overrides = 8;                        // [optional] Overrides for the source file
-    Dimensions dimensions = 9;                          // [required] File data dimensionality, either 2D or 3D
-    repeated TraceHeaderField trace_header_fields = 10; // [optional] The trace header fields that will be used as keys for indexing.
+    SegyOverrides overrides = 7;                        // [optional] Overrides for the source file
+    Dimensions dimensions = 8;                          // [required] File data dimensionality, either 2D or 3D
+    repeated TraceHeaderField trace_header_fields = 9;  // [optional] The trace header fields that will be used as keys for indexing.
 }
 
 message RegisterSourceSegyFileResponse {
@@ -110,7 +109,6 @@ message EditSourceSegyFileResponse {
 
 message UnregisterSourceSegyFileRequest {
     Identifier file = 1;                                // [required] The file unregister
-    bool keep_registered = 2;                           // [optional] Delete contents of file (undo the ingestion), but keep the file registered. Defaults to false
 }
 
 message UnregisterSourceSegyFileResponse {

--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -78,14 +78,14 @@ message DeleteSurveyResponse {
 
 message RegisterSourceSegyFileRequest {
     Identifier survey = 1;                              // [required] The survey this source file belongs to
-    string path = 2;                                    // [required if file is not synthetic] Path including protocol, bucket and directory structure. Example: "gs://cognite-seismic-eu/samples/"
+    string path = 2;                                    // [required] Path including protocol, bucket and directory structure. Example: "gs://cognite-seismic-eu/samples/"
     string name = 3;                                    // [required] Unique filename including extension. Example: "DN1302M03R16_MERGED_KPSDM_00-32_DEG_T.sgy". The name must be unique across buckets and can be used to identify this file in query requests
     ExternalId external_id = 4;                         // [optional] An external identifier - matches service contract field
     map<string, string> metadata = 5;                   // [optional] Any custom-defined metadata
     CRS crs = 6;                                        // [required] Official name of the CRS used. Example: "EPSG:23031"
     SegyOverrides overrides = 7;                        // [optional] Overrides for the source file
-    Dimensions dimensions = 8;                          // [required] File data dimensionality, either 2D or 3D
-    repeated TraceHeaderField trace_header_fields = 9;  // [optional] The trace header fields that will be used as keys for indexing.
+    repeated TraceHeaderField trace_header_fields = 8;  // [optional] The trace header fields that will be used as keys for indexing
+    Dimensions dimensions = 9;                          // [required] File data dimensionality, either 2D or 3D
 }
 
 message RegisterSourceSegyFileResponse {
@@ -93,14 +93,14 @@ message RegisterSourceSegyFileResponse {
 }
 
 message EditSourceSegyFileRequest {
-    Identifier file = 1;                                // [required] The registered source file to edit.
-    string path = 2;                                    // [required if file is not synthetic] Path including protocol, bucket and directory structure. Example: "gs://cognite-seismic-eu/samples/"
+    Identifier file = 1;                                // [required] The registered source file to edit
+    string path = 2;                                    // [required] Path including protocol, bucket and directory structure. Example: "gs://cognite-seismic-eu/samples/"
     string name = 3;                                    // [required] Unique filename including extension. Example: "DN1302M03R16_MERGED_KPSDM_00-32_DEG_T.sgy". The name must be unique across buckets and can be used to identify this file in query requests
     ExternalId external_id = 4;                         // [optional] An external identifier - matches service contract field
     map<string, string> metadata = 5;                   // [optional] Any custom-defined metadata
     CRS crs = 6;                                        // [required] Official name of the CRS used. Example: "EPSG:23031"
     SegyOverrides overrides = 7;                        // [optional] Overrides for the source file
-    repeated TraceHeaderField trace_header_fields = 8;  // [optional] The trace header fields that will be used as keys for indexing.
+    repeated TraceHeaderField trace_header_fields = 8;  // [optional] The trace header fields that will be used as keys for indexing
 }
 
 message EditSourceSegyFileResponse {
@@ -108,12 +108,10 @@ message EditSourceSegyFileResponse {
 }
 
 message UnregisterSourceSegyFileRequest {
-    Identifier file = 1;                                // [required] The file unregister
+    Identifier file = 1;                                // [required] The file to unregister
 }
 
-message UnregisterSourceSegyFileResponse {
-    int64 survey = 1;                                   // The survey the source file belong to
-}
+message UnregisterSourceSegyFileResponse {}
 
 /**
     Seismics

--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -77,14 +77,14 @@ message DeleteSurveyResponse {
 **/
 
 message RegisterSourceSegyFileRequest {
-    Identifier survey = 1;                              // [required] The survey this source file belongs to
-    string path = 2;                                    // [required] Path including protocol, bucket, directory structure, and file name. Example: "gs://cognite-seismic-eu/samples/DN1302M03R16_MERGED_KPSDM_00-32_DEG_T.sgy"
-    ExternalId external_id = 3;                         // [optional] An external identifier - matches service contract field
-    map<string, string> metadata = 4;                   // [optional] Any custom-defined metadata
-    CRS crs = 5;                                        // [required] Official name of the CRS used. Example: "EPSG:23031"
-    SegyOverrides overrides = 6;                        // [optional] Overrides for the source file
-    repeated TraceHeaderField trace_header_fields = 7;  // [optional] The trace header fields that will be used as keys for indexing
-    Dimensions dimensions = 8;                          // [required] File data dimensionality, either 2D or 3D
+    Identifier survey = 1;                     // [required] The survey this source file belongs to
+    string path = 2;                           // [required] Path including protocol, bucket, directory structure, and file name. Example: "gs://cognite-seismic-eu/samples/DN1302M03R16_MERGED_KPSDM_00-32_DEG_T.sgy"
+    ExternalId external_id = 3;                // [optional] An external identifier - matches service contract field
+    map<string, string> metadata = 4;          // [optional] Any custom-defined metadata
+    CRS crs = 5;                               // [required] Official name of the CRS used. Example: "EPSG:23031"
+    SegyOverrides overrides = 6;               // [optional] Overrides for the source file
+    repeated TraceHeaderField key_fields = 7;  // [optional] The trace header fields that will be used as keys for indexing
+    Dimensions dimensions = 8;                 // [required] File data dimensionality, either 2D or 3D
 }
 
 message RegisterSourceSegyFileResponse {
@@ -92,14 +92,14 @@ message RegisterSourceSegyFileResponse {
 }
 
 message EditSourceSegyFileRequest {
-    Identifier file = 1;                                // [required] The registered source file to edit
-    google.protobuf.StringValue path = 2;               // [optional] Path including protocol, bucket, directory structure, and file name. Example: "gs://cognite-seismic-eu/samples/DN1302M03R16_MERGED_KPSDM_00-32_DEG_T.sgy"
-    ExternalId external_id = 3;                         // [optional] An external identifier - matches service contract field
-    map<string, string> metadata = 4;                   // [optional] Any custom-defined metadata
-    CRS crs = 5;                                        // [optional] Official name of the CRS used. Example: "EPSG:23031"
-    SegyOverrides overrides = 6;                        // [optional] Overrides for the source file
-    repeated TraceHeaderField trace_header_fields = 7;  // [optional] The trace header fields that will be used as keys for indexing
-    Dimensions dimensions = 8;                          // [optional] File data dimensionality, either 2D or 3D
+    Identifier file = 1;                       // [required] The registered source file to edit
+    google.protobuf.StringValue path = 2;      // [optional] Path including protocol, bucket, directory structure, and file name. Example: "gs://cognite-seismic-eu/samples/DN1302M03R16_MERGED_KPSDM_00-32_DEG_T.sgy"
+    ExternalId external_id = 3;                // [optional] An external identifier - matches service contract field
+    map<string, string> metadata = 4;          // [optional] Any custom-defined metadata
+    CRS crs = 5;                               // [optional] Official name of the CRS used. Example: "EPSG:23031"
+    SegyOverrides overrides = 6;               // [optional] Overrides for the source file
+    repeated TraceHeaderField key_fields = 7;  // [optional] The trace header fields that will be used as keys for indexing
+    Dimensions dimensions = 8;                 // [optional] File data dimensionality, either 2D or 3D
 }
 
 message EditSourceSegyFileResponse {
@@ -107,7 +107,7 @@ message EditSourceSegyFileResponse {
 }
 
 message UnregisterSourceSegyFileRequest {
-    Identifier file = 1;                                // [required] The file to unregister
+    Identifier file = 1;                       // [required] The file to unregister
 }
 
 message UnregisterSourceSegyFileResponse {}


### PR DESCRIPTION
During file registration, convey which header fields should be used for indexing and their respective offsets

Using the wording "POSTSTACK_2D_SHOTPOINT" to avoid confusion with "ENERGY_SOURCE_POINT"

According to PGS, offset 17 (energy source point) is always present, therefore we are adding support for that field.