### PR TITLE
VolumeBoundsResponse: Add sample_count

### DIFF
--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -206,6 +206,7 @@ message GeometryBasedVolume {
 message VolumeBoundsResponse {
     int32 trace_size_bytes = 1; // The size in bytes of one Trace message
     int32 num_traces = 2;       // The number of traces returned
+    int32 sample_count = 5;     // The number of samples per trace
     string crs = 3;             // CRS of the returned trace coordinates
     // Upper and lower bounds and step sizes in each direction for the returned traces.
     // Null if the result is empty. The iline and xline fields will be null for a line-like geometry.


### PR DESCRIPTION
Turns out we need an explicit sample_count field. I had thought that
could be found from bounds.z, but bounds is not always present. So give
the explicit sample count as well.