### PR TITLE
Return all editable fields

### DIFF
--- a/cognite/seismic/protos/v1/seismic_service_datatypes.proto
+++ b/cognite/seismic/protos/v1/seismic_service_datatypes.proto
@@ -48,7 +48,8 @@ message SourceSegyFile {
     string cloud_storage_path = 7; // The cloud storage path for the file, excluding the file name
     map<string, string> metadata = 5;
     SegyOverrides segy_overrides = 6;
-    repeated TraceHeaderField trace_header_fields = 8; // The trace header fields that will be used as keys for indexing.
+    repeated TraceHeaderField key_fields = 8; // The trace header fields that will be used as keys for indexing.
+    Dimensions dimensions = 9; // File data dimensionality, either 2D or 3D
 }
 
 // Metadata related to interpreting SEG-Y files.

--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -82,7 +82,7 @@ message RegisterSourceSegyFileRequest {
     ExternalId external_id = 3;                // [optional] An external identifier - matches service contract field
     map<string, string> metadata = 4;          // [optional] Any custom-defined metadata
     CRS crs = 5;                               // [required] Official name of the CRS used. Example: "EPSG:23031"
-    SegyOverrides overrides = 6;               // [optional] Overrides for the source file
+    SegyOverrides segy_overrides = 6;          // [optional] Overrides for the source file
     repeated TraceHeaderField key_fields = 7;  // [optional] The trace header fields that will be used as keys for indexing
     Dimensions dimensions = 8;                 // [required] File data dimensionality, either 2D or 3D
 }
@@ -97,7 +97,7 @@ message EditSourceSegyFileRequest {
     ExternalId external_id = 3;                // [optional] An external identifier - matches service contract field
     map<string, string> metadata = 4;          // [optional] Any custom-defined metadata
     CRS crs = 5;                               // [optional] Official name of the CRS used. Example: "EPSG:23031"
-    SegyOverrides overrides = 6;               // [optional] Overrides for the source file
+    SegyOverrides segy_overrides = 6;          // [optional] Overrides for the source file
     repeated TraceHeaderField key_fields = 7;  // [optional] The trace header fields that will be used as keys for indexing
     Dimensions dimensions = 8;                 // [optional] File data dimensionality, either 2D or 3D
 }


### PR DESCRIPTION
Since `dimensions` is also editable, it would make sense to returned it in the `SourceSegyFile` message
Also, keep a consistent naming of the fields between the request message and the response message