### PR TITLE
Specify trace header key for include_extent

### DIFF
--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -146,7 +146,7 @@ message SearchSeismicsRequest {
     bool include_line_range = 6;
     bool include_volume_definition = 7;  // If true, include the volume definition blob
     bool include_cutout = 12;            // If true, include the cutout specification the seismicstore was created with
-    bool include_extent = 13;            // If true, include a description of the included traces
+    bool include_extent = 13;            // If true, include a description of the included traces, using the seismic's native trace header key
     bool include_seismic_store = 8;      // If true, include info on the backing seismicstore. Must be data manager.
     bool include_partition = 9;          // If true, include info on the partition. Must be data manager.\
     bool include_coverage = 10;          // Deprecated. Use `coverage` instead.
@@ -177,7 +177,9 @@ message SearchSeismicStoresRequest {
     }
     bool include_file_info = 2;  // If true, include File information in the response
     bool include_volume_definitions = 3; // If true, includes inline/crossline volume definitions for store
-    bool include_extent = 9; // If true, include a description of the traces contained in the seismicstore
+    // If true, include a description of the included traces, using the specified header
+    // as the trace key (for 2d) or the major direction (for 3d)
+    TraceHeaderField include_extent = 9;
     bool include_headers = 5; // if true, include text and binary headers in the response
     bool include_coverage = 4; // Deprecated. Use `coverage` instead.
     CoverageSpec coverage = 7; // If specified, include coverage

--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -177,7 +177,7 @@ message SearchSeismicStoresRequest {
     }
     bool include_file_info = 2;  // If true, include File information in the response
     bool include_volume_definitions = 3; // If true, includes inline/crossline volume definitions for store
-    // If true, include a description of the included traces, using the specified header
+    // If specified, include a description of the included traces, using the specified header
     // as the trace key (for 2d) or the major direction (for 3d)
     TraceHeaderField include_extent = 9;
     bool include_headers = 5; // if true, include text and binary headers in the response


### PR DESCRIPTION
This is an idea I had: When the user requests an extent for a seismicstore, we don't really know which key header to use. So let the user specify which.

Not sure if this is the right solution. Other suggestions?

Also, should we do the same for Seismics and rely on our magic translation abilities to return the right extent?