### PR TITLE
GetSegYFile - 2d support

### DIFF
--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -312,8 +312,6 @@ message SegYSeismicRequest {
         Identifier seismic = 1;
         int64 seismic_store_id = 2;  // Need to be a data manager or tenant user, not 3rd party, to access by seismic store
     }
-    // This only supports queries to 3D objects.
-    // Deprecated. Use filter instead.
     oneof query {
         Geometry polygon = 3;
         LineBasedRectangle lines = 4;         // Only valid if the queried object is 3D. Deprecated. Use three_dee_extent instead.

--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -310,11 +310,18 @@ message TraceBounds {
 message SegYSeismicRequest {
     oneof identifier {
         Identifier seismic = 1;
-        int64 seismic_store_id = 2;
+        int64 seismic_store_id = 2;  // Need to be a data manager or tenant user, not 3rd party, to access by tracestore
     }
+    // This only supports queries to 3D objects.
+    // Deprecated. Use filter instead.
     oneof query {
         Geometry polygon = 3;
         LineBasedRectangle lines = 4;
+    }
+    oneof filter {
+        Seismic2dExtent two_dee_extent = 5;   // only valid if the queried object is 2D
+        Seismic3dExtent three_dee_extent = 6; // only valid if the queried object is 3D
+        GeometryFilter geometry = 7;
     }
 }
 

--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -316,12 +316,9 @@ message SegYSeismicRequest {
     // Deprecated. Use filter instead.
     oneof query {
         Geometry polygon = 3;
-        LineBasedRectangle lines = 4;
-    }
-    oneof filter {
-        Seismic2dExtent two_dee_extent = 5;   // only valid if the queried object is 2D
-        Seismic3dExtent three_dee_extent = 6; // only valid if the queried object is 3D
-        GeometryFilter geometry = 7;
+        LineBasedRectangle lines = 4;         // Only valid if the queried object is 3D. Deprecated. Use three_dee_extent instead.
+        Seismic2dExtent two_dee_extent = 5;   // Only valid if the queried object is 2D
+        Seismic3dExtent three_dee_extent = 6; // Only valid if the queried object is 3D
     }
 }
 

--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -310,7 +310,7 @@ message TraceBounds {
 message SegYSeismicRequest {
     oneof identifier {
         Identifier seismic = 1;
-        int64 seismic_store_id = 2;  // Need to be a data manager or tenant user, not 3rd party, to access by tracestore
+        int64 seismic_store_id = 2;  // Need to be a data manager or tenant user, not 3rd party, to access by seismic store
     }
     // This only supports queries to 3D objects.
     // Deprecated. Use filter instead.


### PR DESCRIPTION
Adding the new extent/geometry types to the existing SegYSeismicRequest. My thinking was we can convert a `query` into a `filter` until we decide to remove it, and the 0.3 sdk only has to deal with `filter`. Or we could have an entirely new message/rpc, I'm happy with either approach really.