### PR TITLE
Extents - Drop seismic prefix

### DIFF
--- a/cognite/seismic/protos/v1/seismic_service_datatypes.proto
+++ b/cognite/seismic/protos/v1/seismic_service_datatypes.proto
@@ -108,7 +108,7 @@ message Survey {
     LineRange line_range = 8; // The minimum and maximum extents of the seismic's grid, described in inlines and crosslines.
     VolumeDef volume_def = 9; // The VolumeDef describing the seismic
     SeismicCutout cutout = 15; // The cutout the seismic object was created with
-    SeismicExtent extent = 16; // A description of the traces contained in the seismic
+    Extent extent = 16; // A description of the traces contained in the seismic
     int64 partition_id = 10; //The id of the partition the seismic belongs to
     int64 seismicstore_id = 11;  // The id of the seismicstore the seismic is derived from. It is present only if agent has READ access and ALL scope  
     Geometry coverage = 12; //The coverage geometry for the seismic.
@@ -118,18 +118,11 @@ message Survey {
 
 message SeismicCutout {
     oneof cutout {
-        Seismic2dExtent two_dee_extent = 1;
-        Seismic3dExtent three_dee_extent = 2;
+        TwoDeeExtent two_dee_extent = 1;
+        ThreeDeeExtent three_dee_extent = 2;
         Geometry geometry = 3;
     }
 };
-
-message SeismicExtent {
-    oneof extent {
-        Seismic2dExtent two_dee_extent = 1;
-        Seismic3dExtent three_dee_extent = 2;
-    }
-}
 
 /**
 Represents a seismic store.
@@ -144,7 +137,7 @@ message SeismicStore {
     SourceSegyFile ingested_source_file = 14; // If present, the file this SeismicStore was ingested from.
     VolumeDef inline_volume_def = 7; // Volume definition for the store, indexed on inlines. Maps from an inline to all of its valid crosslines.
     VolumeDef crossline_volume_def = 8; // Volume definition for the store, indexed on crosslines. Maps from a crossline to all of its valid inlines
-    SeismicExtent extent = 13; // Description of the traces contained in the seismicstore.
+    Extent extent = 13; // Description of the traces contained in the seismicstore.
     TextHeader text_header = 9; //If present, the text header for this seismic store
     BinaryHeader binary_header = 10; //If present, the binary header for this seismic store
     // Tenant specific name for the storage facility the trace data are stored in. If empty, it is stored in an unspecified trace store.
@@ -326,33 +319,40 @@ message GeometryFilter {
     InterpolationMethod interpolation_method = 2; // Only used for linear geometries in 3D
 }
 
-message Seismic2dExtent {
+message Extent {
+    oneof extent {
+        TwoDeeExtent two_dee_extent = 1;
+        ThreeDeeExtent three_dee_extent = 2;
+    }
+}
+
+message TwoDeeExtent {
     TraceHeaderField trace_key = 1; // Must be an applicable field for 2D
     repeated LineDescriptor trace_ranges = 2; // Range of header values to use
 }
 
-message Seismic2dRange {
+message TwoDeeRange {
     TraceHeaderField trace_key = 1; // Must be an applicable field for 2D
     LineDescriptor trace_range = 2;
 }
 
-message Seismic3dExtent {
+message ThreeDeeExtent {
     oneof type {
-        Seismic3dRects rects = 1;
-        Seismic3dDef def = 2;
+        ThreeDeeRects rects = 1;
+        ThreeDeeDef def = 2;
     }
 }
 
-message Seismic3dRects {
-    repeated Seismic3dRect rects = 1;
+message ThreeDeeRects {
+    repeated ThreeDeeRect rects = 1;
 }
 
-message Seismic3dRect {
+message ThreeDeeRect {
     LineDescriptor inline_range = 1;
     LineDescriptor xline_range = 2;
 }
 
-message Seismic3dDef {
+message ThreeDeeDef {
     TraceHeaderField major_header = 1; // Must be inline or crossline
     TraceHeaderField minor_header = 2; // Must be inline or crossline, and different from major_header
     map<int32, MinorLines> lines = 3;

--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -148,8 +148,8 @@ message CreateSeismicRequest {
         VolumeDef volume_def = 5;  // Define the volume as VolumeDef format
         Geometry geometry = 7;  // Defines the volume as WKT or GeoJson
         bool empty = 10;  // If true, will create a seismic with an empty cutout
-        Seismic2dExtent two_dee_extent = 12;   // only valid if the seismic is 2D
-        Seismic3dExtent three_dee_extent = 13; // only valid if the seismic is 3D
+        TwoDeeExtent two_dee_extent = 12;   // only valid if the seismic is 2D
+        ThreeDeeExtent three_dee_extent = 13; // only valid if the seismic is 3D
     }
     OptionalMap metadata = 6;
     TextHeader text_header = 8;  // Optionally set a custom text header
@@ -287,8 +287,8 @@ message StreamTracesRequest {
         int64 seismic_store_id = 2;  // Need to be a data manager or tenant user, not 3rd party, to access by tracestore
     }
     oneof filter {
-        Seismic2dExtent two_dee_extent = 3;   // only valid if the queried object is 2D
-        Seismic3dExtent three_dee_extent = 4; // only valid if the queried object is 3D
+        TwoDeeExtent two_dee_extent = 3;   // only valid if the queried object is 2D
+        ThreeDeeExtent three_dee_extent = 4; // only valid if the queried object is 3D
         GeometryFilter geometry = 5;
     }
     LineDescriptor z_range = 6;

--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -303,7 +303,7 @@ message TraceBounds {
     LineDescriptor z_range = 5;     // The actual range of z values returned
     oneof bounds {
         cognite.seismic.v1.LineRange three_dee_bounds = 6; // Will be null for a line-like geometry
-        Seismic2dRange two_dee_bounds = 7;
+        TwoDeeRange two_dee_bounds = 7;
     }
 }
 


### PR DESCRIPTION
`SeismicExtent` makes sense when creating seismics but when returning an extent from a seismic store or using an extent as a filter for trace streaming, the prefix might be confusing