### PR TITLE
SeismicCutout empty variant

### DIFF
--- a/cognite/seismic/protos/v1/seismic_service_datatypes.proto
+++ b/cognite/seismic/protos/v1/seismic_service_datatypes.proto
@@ -112,15 +112,16 @@ message Survey {
     int64 partition_id = 10; //The id of the partition the seismic belongs to
     int64 seismicstore_id = 11;  // The id of the seismicstore the seismic is derived from. It is present only if agent has READ access and ALL scope  
     Geometry coverage = 12; //The coverage geometry for the seismic.
-    bool created_empty = 13; // If true, this seismic was created with the 'empty' volume option and thus will have no trace data available
+    bool created_empty = 13; // If true, this seismic was created empty (deprecated)
     int64 trace_count = 14;  // Provides an estimate of the number of traces contained within the seismic.
 }
 
 message SeismicCutout {
     oneof cutout {
-        Seismic2dExtent two_dee_extent = 1;
-        Seismic3dExtent three_dee_extent = 2;
-        Geometry geometry = 3;
+        Seismic2dExtent two_dee_extent = 1; // Indicates that the seismic was requested with this 2D extent
+        Seismic3dExtent three_dee_extent = 2; // Indicates that the seismic was requested with this 3D extent (or an equivalent VolumeDef)
+        Geometry geometry = 3; // Indicates that the seismic was requested with this geometry
+        google.protobu.Empty empty = 4; // Indicates that the seismic was created empty
     }
 };
 

--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -166,7 +166,7 @@ message SearchSeismicsRequest {
     bool include_text_header = 4;
     bool include_binary_header = 5;
     bool include_line_range = 6;
-    bool include_volume_definition = 7;  // If true, include the volume definition blob
+    bool include_volume_definition = 7;  // If true, include the volume definition
     bool include_cutout = 12;            // If true, include the cutout specification the seismic was created with
     bool include_extent = 13;            // If true, include a description of the included traces
     bool include_seismic_store = 8;      // If true, include info on the backing seismicstore. Must be data manager.

--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -167,7 +167,7 @@ message SearchSeismicsRequest {
     bool include_binary_header = 5;
     bool include_line_range = 6;
     bool include_volume_definition = 7;  // If true, include the volume definition blob
-    bool include_cutout = 12;            // If true, include the cutout specification the seismicstore was created with
+    bool include_cutout = 12;            // If true, include the cutout specification the seismic was created with
     bool include_extent = 13;            // If true, include a description of the included traces
     bool include_seismic_store = 8;      // If true, include info on the backing seismicstore. Must be data manager.
     bool include_partition = 9;          // If true, include info on the partition. Must be data manager.\


### PR DESCRIPTION
Deprecate the `created_empty` field in favor of a dedicated `empty` variant in the `SeismicCutout` message.