### PR TITLE
SeismicCutout: Add `full` variant

### DIFF
--- a/cognite/seismic/protos/v1/seismic_service_datatypes.proto
+++ b/cognite/seismic/protos/v1/seismic_service_datatypes.proto
@@ -128,6 +128,7 @@ message SeismicCutout {
         Seismic3dExtent three_dee_extent = 2; // Indicates that the seismic was requested with this 3D extent (or an equivalent VolumeDef)
         Geometry geometry = 3; // Indicates that the seismic was requested with this geometry
         bool empty = 4; // Indicates that the seismic was created empty
+        bool full = 5; // Indicates that the seismic was created to cover the entire seismicstore
     }
 };
 


### PR DESCRIPTION
to indicate that the seismic was created with `volume = null`, so it
inherits its extents from the seismicstore.

We won't be able to return this variant for 3D seismics, because there is no way to distinguish those seismics that were created before we started recording the source cutouts, from those that were created with `volume = null`. But we can do it for 2d cutouts.

What should we do with the 3d cutouts?