### PR TITLE
TraceBounds: Return both cdp bounds and extent bounds

### DIFF
--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -313,8 +313,15 @@ message TraceBounds {
     LineDescriptor z_range = 5;     // The actual range of z values returned
     oneof bounds {
         cognite.seismic.v1.LineRange three_dee_bounds = 6; // Will be null for a line-like geometry
-        Seismic2dRange two_dee_bounds = 7;
+        TwoDeeBounds two_dee_bounds = 7;
     }
+}
+
+message TwoDeeBounds {
+    // A range bounding the trace header values of the returned traces,
+    // using the trace key specified in the extent (if any)
+    Seismic2dRange bounds = 1;
+    LineDescriptor cdp_bounds = 2;  // A range bounding the CDP numbers of the returned traces
 }
 
 message SegYSeismicRequest {


### PR DESCRIPTION
This might be one way to get `get_array` to work correctly when passed a shotpoint extent. People will still be interested in the shotpoint bounds, but `get_array` needs the cdp bounds to index into the array correctly. So return both.

This is a breaking change, but the `GetTraceBounds` endpoint is still not used (since we haven't released the sdk yet).