### PR TITLE
Support survey search by geometry

### DIFF
--- a/cognite/seismic/protos/v1/seismic_service_datatypes.proto
+++ b/cognite/seismic/protos/v1/seismic_service_datatypes.proto
@@ -221,6 +221,7 @@ message SearchSpec {
         string name = 4;  // An exact string match is required
         string name_substring = 5;  // Searches for names having this substring.
         MetadataFilter metadata = 7;  // Filters by metadata. Currently only supported by Surveys.
+        Geometry geometry = 8; // Filters by intersection with a geometry. Currently only supported by Surveys.
     }
 }
 


### PR DESCRIPTION
Fun fact: This change automatically also gives an API for searching for other objects (seismicstores, seismics) by geometry. But that's for later.