### PR TITLE
Add endpoint to debug ingestion

### DIFF
--- a/cognite/seismic/protos/v1/seismic_service.proto
+++ b/cognite/seismic/protos/v1/seismic_service.proto
@@ -111,7 +111,7 @@ service SeismicAPI {
     * Inspect the seismicstore resulting from a possibly failed ingestion. Useful for 
     * debugging failed ingestions.
     */
-    rpc InspectIngestion (InspectIngestionRequest) returns (SeismicStore) {}
+    rpc InspectIngestion (InspectIngestionRequest) returns (InspectIngestionResponse) {}
 
     /**
      * Set the name of a seismic store object.

--- a/cognite/seismic/protos/v1/seismic_service.proto
+++ b/cognite/seismic/protos/v1/seismic_service.proto
@@ -108,6 +108,12 @@ service SeismicAPI {
     rpc SearchSeismicStores (SearchSeismicStoresRequest) returns (stream SeismicStore) {}
 
     /**
+    * Inspect the seismicstore resulting from a possibly failed ingestion. Useful for 
+    * debugging failed ingestions.
+    */
+    rpc InspectIngestion (InspectIngestionRequest) returns (SeismicStore) {}
+
+    /**
      * Set the name of a seismic store object.
      **/
     rpc EditSeismicStore (EditSeismicStoreRequest) returns (SeismicStore) {}

--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -220,8 +220,12 @@ message InspectIngestionRequest {
     oneof identifier {
         int64 seismic_store_id = 1;
         int64 file_id = 2;
+        string job_id = 3;
     }
-    bool allow_unpublished = 3;
+}
+
+message InspectIngestionResponse {
+    SeismicStore seismic_store = 1;
 }
 
 message EditSeismicStoreRequest {

--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -216,6 +216,14 @@ message SearchSeismicStoresRequest {
     CoverageSpec coverage = 7; // If specified, include coverage
 }
 
+message InspectIngestionRequest {
+    oneof identifier {
+        int64 seismic_store_id = 1;
+        int64 file_id = 2;
+    }
+    bool allow_unpublished = 3;
+}
+
 message EditSeismicStoreRequest {
     int64 seismic_store_id = 1; // Deprecated. Use `identifier` instead.
     google.protobuf.StringValue name = 2; // If not null will change the seismic store name


### PR DESCRIPTION
Some failed ingestion results are really hard to debug. It can help to
get a look at what the ingestion worker has seen so far before failing,
such as trace extents. Here is a suggested endpoint to peek at the
unpublished seismicstore resulting from a failed ingestion, in order to
debug.

Alternatively, we could add `allow_unpublished` to
`SearchSeismicStoresRequest`, but keeping it as a separate endpoint
which is explicitly meant for debugging seems to more clearly
communicate the debugging intent.

Are there any potential consistency problems with allowing data managers
to see unpublished seismic stores like this?

Also, naming is hard. Alternatives welcome.