### PR TITLE
[SEIS-1173] Prestack: Add trace header fields.

### DIFF
--- a/cognite/seismic/protos/v1/seismic_service_datatypes.proto
+++ b/cognite/seismic/protos/v1/seismic_service_datatypes.proto
@@ -334,8 +334,8 @@ enum TraceHeaderField {
     INLINE = 3;
     CROSSLINE = 4;
     SHOTPOINT = 5;
-    TRACE_NUMBER_WITHIN_ENSEMBLE = 6; // bytes 25-28 of Standard Trace Header.
-    DISTANCE_FROM_SOURCE = 7;  // bytes 37-40. Distance from center of source point to the center of receiver group.
+    CDP_TRACE = 6; // bytes 25-28 of Standard Trace Header, aka trace number within ensemble
+    OFFSET = 7;  // bytes 37-40. Distance from center of source point to the center of receiver group.
 }
 
 message GeometryFilter {

--- a/cognite/seismic/protos/v1/seismic_service_datatypes.proto
+++ b/cognite/seismic/protos/v1/seismic_service_datatypes.proto
@@ -334,6 +334,8 @@ enum TraceHeaderField {
     INLINE = 3;
     CROSSLINE = 4;
     SHOTPOINT = 5;
+    TRACE_NUMBER_WITHIN_ENSEMBLE = 6; // bytes 25-28 of Standard Trace Header.
+    DISTANCE_FROM_SOURCE = 7;  // bytes 37-40. Distance from center of source point to the center of receiver group.
 }
 
 message GeometryFilter {

--- a/cognite/seismic/protos/v1/seismic_service_datatypes.proto
+++ b/cognite/seismic/protos/v1/seismic_service_datatypes.proto
@@ -334,7 +334,7 @@ enum TraceHeaderField {
     INLINE = 3;
     CROSSLINE = 4;
     SHOTPOINT = 5;
-    CDP_TRACE = 6; // bytes 25-28 of Standard Trace Header, aka trace number within ensemble
+    CDP_TRACE = 6; // bytes 25-28 of standard trace header: trace number within ensemble
     OFFSET = 7;  // bytes 37-40. Distance from center of source point to the center of receiver group.
 }
 

--- a/cognite/seismic/protos/v1/seismic_service_datatypes.proto
+++ b/cognite/seismic/protos/v1/seismic_service_datatypes.proto
@@ -335,7 +335,7 @@ enum TraceHeaderField {
     CROSSLINE = 4;
     SHOTPOINT = 5;
     CDP_TRACE = 6; // bytes 25-28 of standard trace header: trace number within ensemble
-    OFFSET = 7;  // bytes 37-40. Distance from center of source point to the center of receiver group.
+    OFFSET = 7;  // bytes 37-40 of standard trace header: distance from center of source point to the center of receiver group.
 }
 
 message GeometryFilter {


### PR DESCRIPTION
~~I changed the names from the ticket:~~

* ~~CDP_TRACE -> TRACE_NUMBER_WITHIN_ENSEMBLE~~
* ~~OFFSET -> DISTANCE_FROM_SOURCE~~

~~I did this because I think it's better to err on the side of verbosity for fields that don't necessarily have a standard name. I personally wasn't sure what CDP_TRACE/CDP difference was at first glance, and OFFSET could've been anything (byte offset?). Opinions welcome.~~

They are fairly industry standard names, we are stickign with them it seems...

Similar PRs for schema and service to follow.