### PR TITLE
Add skip_messages field to SegYSeismicRequest

### DIFF
--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -349,6 +349,7 @@ message SegYSeismicRequest {
         Seismic3dExtent three_dee_extent = 6; // Only valid if the queried object is 3D
     }
     int32 skip_message_count = 7; // Skip the first n chunks of the download. Useful for resuming aborted downloads. Default: 0.
+    string etag = 8; // Entity tag from a previous download request. Useful for making sure we are resuming the same entity.
 }
 
 message SegYSeismicResponse {

--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -348,7 +348,7 @@ message SegYSeismicRequest {
         Seismic2dExtent two_dee_extent = 5;   // Only valid if the queried object is 2D
         Seismic3dExtent three_dee_extent = 6; // Only valid if the queried object is 3D
     }
-    int32 skip_messages = 7; // Skip the first n chunks of the download. Useful for resuming aborted downloads. Default: 0.
+    int32 skip_message_count = 7; // Skip the first n chunks of the download. Useful for resuming aborted downloads. Default: 0.
 }
 
 message SegYSeismicResponse {

--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -348,6 +348,7 @@ message SegYSeismicRequest {
         Seismic2dExtent two_dee_extent = 5;   // Only valid if the queried object is 2D
         Seismic3dExtent three_dee_extent = 6; // Only valid if the queried object is 3D
     }
+    int32 skip_messages = 7; // Skip the first n chunks of the download. Useful for resuming aborted downloads. Default: 0.
 }
 
 message SegYSeismicResponse {

--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -349,7 +349,6 @@ message SegYSeismicRequest {
         Seismic3dExtent three_dee_extent = 6; // Only valid if the queried object is 3D
     }
     int32 skip_message_count = 7; // Skip the first n chunks of the download. Useful for resuming aborted downloads. Default: 0.
-    string etag = 8; // Entity tag from a previous download request. Useful for making sure we are resuming the same entity.
 }
 
 message SegYSeismicResponse {


### PR DESCRIPTION
for resumable grpc downloads. Suggestions for different naming is welcome.

We might also want to add a field to identify the revision. Something like an etag, (which would need to be included in one of the `SegYSeismicResponse`s?) or a `last_updated` date.