### PR TITLE
CreateSeismic - Create cutout on trace groups

### DIFF
--- a/cognite/seismic/protos/v1/seismic_service_datatypes.proto
+++ b/cognite/seismic/protos/v1/seismic_service_datatypes.proto
@@ -386,6 +386,17 @@ message MinorLines {
     repeated LineDescriptor ranges = 1;
 }
 
+message SeismicTraceGroupExtent {
+    oneof type {
+        SeismicTraceGroupLines lines = 1;
+    }
+}
+
+message SeismicTraceGroupLines {
+    TraceHeaderField group_header = 1; // The trace header to differentiate between prestack-migrated duplicate major/minor traces
+    repeated LineDescriptor lines = 2;
+}
+
 // Specifies a last modified timestamp range to search.
 // Returned objects will satisfy all arguments that are not null.
 message LastModifiedFilter {

--- a/cognite/seismic/protos/v1/seismic_service_messages.proto
+++ b/cognite/seismic/protos/v1/seismic_service_messages.proto
@@ -156,6 +156,10 @@ message CreateSeismicRequest {
     TextHeader text_header = 8;  // Optionally set a custom text header
     BinaryHeader binary_header = 9;  // Optionally set a custom binary header
     bool copy_metadata = 11;  // If true, copy the metadata from the source seismic store.
+    oneof psm_trace_group_cutout {
+        bool empty = 14;  // If true, will create a prestack-migrated seismic with an empty trace group cutout
+        SeismicTraceGroupExtent trace_group_extent = 15; // Valid if the seismic is 2D or 3D
+    }
 }
 
 message SearchSeismicsRequest {


### PR DESCRIPTION
Differs a bit from https://github.com/cognitedata/seismic-proto/pull/205 so putting for review now to get thoughts on this. It seems that we can't guarantee that cdp_trace will always be present for psm 2d/3d and a different trace header like offset may be used. So we need to be able to specify the trace header when creating the cutout (and when filtering on a trace stream request too), and translating to other supported psm trace headers if needed